### PR TITLE
HotFix: 앱 충돌 수정

### DIFF
--- a/Projects/App/Sources/Intro/IntroFeature.swift
+++ b/Projects/App/Sources/Intro/IntroFeature.swift
@@ -42,7 +42,7 @@ public struct IntroFeature {
         case .splash(let splashAction):
             return splashDelegate(splashAction, state: &state)
             
-        case .login(.scope(.signUpDone(.dismissLoginRootView))):
+        case .login(.delegate(.dismissLoginRootView)):
             return .run { send in await send(.delegate(.moveToTab)) }
             
         case .delegate, .login:

--- a/Projects/App/Sources/Intro/IntroView.swift
+++ b/Projects/App/Sources/Intro/IntroView.swift
@@ -31,7 +31,6 @@ public extension IntroView {
                     if let store = store.scope(state: \.login, action: \.login) {
                         LoginRootView(store: store)
                     }
-                    
                 }
             }
         }

--- a/Projects/Feature/FeatureLogin/Sources/LoginRoot/LoginRootFeature.swift
+++ b/Projects/Feature/FeatureLogin/Sources/LoginRoot/LoginRootFeature.swift
@@ -37,7 +37,6 @@ public struct LoginRootFeature {
             case pushRegisterNicknameView
             case pushSelectFieldView
             case pushSignUpDoneView
-            case dismissLoginRootView
         }
         public enum AsyncAction: Equatable { case doNothing }
         public enum ScopeAction {
@@ -46,7 +45,9 @@ public struct LoginRootFeature {
             case selectField(SelectFieldFeature.Action.DelegateAction)
             case signUpDone(SignUpDoneFeature.Action.DelegateAction)
         }
-        public enum DelegateAction: Equatable { case doNothing }
+        public enum DelegateAction: Equatable {
+            case dismissLoginRootView
+        }
     }
     /// initiallizer
     public init() {}
@@ -102,8 +103,6 @@ private extension LoginRootFeature {
         case .pushSignUpDoneView:
             state.path.append(.signUpDone(.init()))
             return .none
-        case .dismissLoginRootView:
-            return .run { _ in await self.dismiss() }
         }
     }
     /// - Async Effect
@@ -131,7 +130,7 @@ private extension LoginRootFeature {
         case .signUpDone(let delegate):
             switch delegate {
             case .dismissLoginRootView:
-                return .send(.inner(.dismissLoginRootView))
+                return .send(.delegate(.dismissLoginRootView))
             }
         }
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #62 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 테스트 플라이트로 어플을 받았을 시에, 로그인에서 메인으로 넘어가는 상황에서 앱 충돌이 일어나는 것을 해결하고자 하였습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
- 로그인 화면을 구현할 당시 FullScreenCover로 사용될 것을 염두하고 `dismiss`코드를 넣었던게 원인이지 않았을까 하여 해당 코드를 제거하였습니다.
- 시뮬레이터, 로컬 빌드 설치에는 충돌이 안일어나서 이번 pr을 머지하고 결과를 확인해볼 예정입니다.

close #62 
