### PR TITLE
feat: Pokit Flow API Connect

### DIFF
--- a/Projects/CoreKit/Sources/CoreNetwork/MoyaProvider+request.swift
+++ b/Projects/CoreKit/Sources/CoreNetwork/MoyaProvider+request.swift
@@ -34,4 +34,23 @@ extension MoyaProvider {
             }
         }
     }
+    
+    func requestNoBody(_ target: Target) async throws -> Void {
+        return try await withCheckedThrowingContinuation { continuation in
+            self.request(target) { response in
+                switch response {
+                case .success:
+                    continuation.resume()
+
+                case .failure(let error):
+                    if let response = error.response?.data {
+                        let errorResponse = try? JSONDecoder().decode(ErrorResponse.self, from: response)
+                        continuation.resume(throwing: errorResponse ?? .base)
+                    } else {
+                        continuation.resume(throwing: error)
+                    }
+                }
+            }
+        }
+    }
 }

--- a/Projects/CoreKit/Sources/Data/DTO/Base/BasePageableRequest.swift
+++ b/Projects/CoreKit/Sources/Data/DTO/Base/BasePageableRequest.swift
@@ -7,8 +7,14 @@
 
 import Foundation
 /// Pageable
-public struct BasePageableRequest: Encodable {
+public struct BasePageableRequest: Equatable, Encodable {
     let page: Int
     let size: Int
     let sort: [String]
+    
+    public init(page: Int, size: Int, sort: [String]) {
+        self.page = page
+        self.size = size
+        self.sort = sort
+    }
 }

--- a/Projects/CoreKit/Sources/Data/DTO/Category/CategoryEditRequest.swift
+++ b/Projects/CoreKit/Sources/Data/DTO/Category/CategoryEditRequest.swift
@@ -8,6 +8,11 @@
 import Foundation
 /// 카테고리 추가 및 수정  API Request
 public struct CategoryEditRequest: Encodable {
-    let categoryName: String
-    let categoryImageId: Int
+    public let categoryName: String
+    public let categoryImageId: Int
+    
+    public init(categoryName: String, categoryImageId: Int) {
+        self.categoryName = categoryName
+        self.categoryImageId = categoryImageId
+    }
 }

--- a/Projects/CoreKit/Sources/Data/Network/Category/CategoryClient.swift
+++ b/Projects/CoreKit/Sources/Data/Network/Category/CategoryClient.swift
@@ -18,22 +18,20 @@ extension DependencyValues {
 }
 /// Category에 관련한 API를 처리하는 Client
 public struct CategoryClient {
-    var 카테고리_삭제: @Sendable (
+    public var 카테고리_삭제: @Sendable (
         _ categoryId: String
     ) async throws -> EmptyResponse
-    var 카테고리_수정: @Sendable (
+    public var 카테고리_수정: @Sendable (
         _ categoryId: String,
         _ model: CategoryEditRequest
     ) async throws -> CategoryEditResponse
-    var 카테고리_목록_조회: @Sendable (
-        _ model: BasePageableRequest
-    ) async throws -> CategoryListInquiryResponse
-    var 카테고리_생성: @Sendable (
+    public var 카테고리_목록_조회: @Sendable (_ model: BasePageableRequest, _ filterUncategorized: Bool) async throws -> CategoryListInquiryResponse
+    public var 카테고리_생성: @Sendable (
         _ model: CategoryEditRequest
     ) async throws -> CategoryEditResponse
-    var 카테고리_프로필_목록_조회: @Sendable (
-    ) async throws -> [CategoryImageResponse]
-    var 유저_카테고리_개수_조회: @Sendable (
+    public var 카테고리_프로필_목록_조회: @Sendable (
+) async throws -> [CategoryImageResponse]
+    public var 유저_카테고리_개수_조회: @Sendable (
     ) async throws -> CategoryCountResponse
 }
 
@@ -48,8 +46,8 @@ extension CategoryClient: DependencyKey {
             카테고리_수정: { id, model in
                 try await provider.request(.카테고리_수정(categoryId: id, model: model))
             },
-            카테고리_목록_조회: { model in
-                try await provider.request(.카테고리_목록_조회(model: model))
+            카테고리_목록_조회: { model, categoryFilter in
+                try await provider.request(.카테고리_목록_조회(model: model, filterUncategorized: categoryFilter))
             },
             카테고리_생성: { model in
                 try await provider.request(.카테고리생성(model: model))
@@ -67,7 +65,7 @@ extension CategoryClient: DependencyKey {
         Self(
             카테고리_삭제: { _ in .init() },
             카테고리_수정: { _, _ in .mock },
-            카테고리_목록_조회: { _ in .mock },
+            카테고리_목록_조회: { _, _ in .mock },
             카테고리_생성: { _ in .mock },
             카테고리_프로필_목록_조회: { CategoryImageResponse.mock },
             유저_카테고리_개수_조회: { .mock }

--- a/Projects/CoreKit/Sources/Data/Network/Category/CategoryClient.swift
+++ b/Projects/CoreKit/Sources/Data/Network/Category/CategoryClient.swift
@@ -18,9 +18,7 @@ extension DependencyValues {
 }
 /// Category에 관련한 API를 처리하는 Client
 public struct CategoryClient {
-    public var 카테고리_삭제: @Sendable (
-        _ categoryId: String
-    ) async throws -> EmptyResponse
+    public var 카테고리_삭제: @Sendable (_ categoryId: Int) async throws -> Void
     public var 카테고리_수정: @Sendable (
         _ categoryId: String,
         _ model: CategoryEditRequest
@@ -41,7 +39,7 @@ extension CategoryClient: DependencyKey {
 
         return Self(
             카테고리_삭제: { id in
-                try await provider.request(.카테고리_삭제(categoryId: id))
+                try await provider.requestNoBody(.카테고리_삭제(categoryId: id))
             },
             카테고리_수정: { id, model in
                 try await provider.request(.카테고리_수정(categoryId: id, model: model))
@@ -63,7 +61,7 @@ extension CategoryClient: DependencyKey {
 
     public static let previewValue: Self = {
         Self(
-            카테고리_삭제: { _ in .init() },
+            카테고리_삭제: { _ in },
             카테고리_수정: { _, _ in .mock },
             카테고리_목록_조회: { _, _ in .mock },
             카테고리_생성: { _ in .mock },

--- a/Projects/CoreKit/Sources/Data/Network/Category/CategoryClient.swift
+++ b/Projects/CoreKit/Sources/Data/Network/Category/CategoryClient.swift
@@ -20,7 +20,7 @@ extension DependencyValues {
 public struct CategoryClient {
     public var 카테고리_삭제: @Sendable (_ categoryId: Int) async throws -> Void
     public var 카테고리_수정: @Sendable (
-        _ categoryId: String,
+        _ categoryId: Int,
         _ model: CategoryEditRequest
     ) async throws -> CategoryEditResponse
     public var 카테고리_목록_조회: @Sendable (_ model: BasePageableRequest, _ filterUncategorized: Bool) async throws -> CategoryListInquiryResponse

--- a/Projects/CoreKit/Sources/Data/Network/Category/CategoryEndpoint.swift
+++ b/Projects/CoreKit/Sources/Data/Network/Category/CategoryEndpoint.swift
@@ -13,7 +13,7 @@ import Moya
 public enum CategoryEndpoint {
     case 카테고리_삭제(categoryId: String)
     case 카테고리_수정(categoryId: String, model: CategoryEditRequest)
-    case 카테고리_목록_조회(model: BasePageableRequest)
+    case 카테고리_목록_조회(model: BasePageableRequest, filterUncategorized: Bool)
     case 카테고리생성(model: CategoryEditRequest)
     case 카테고리_프로필_목록_조회
     case 유저_카테고리_개수_조회
@@ -65,12 +65,13 @@ extension CategoryEndpoint: TargetType {
             return .requestPlain
         case let .카테고리_수정(_, model):
             return .requestJSONEncodable(model)
-        case let .카테고리_목록_조회(model):
+        case let .카테고리_목록_조회(model, categorized):
             return .requestParameters(
                 parameters: [
                     "page": model.page,
                     "size": model.size,
-                    "sort": model.sort
+                    "sort": model.sort,
+                    "filterUncategorized": categorized
                 ],
                 encoding: URLEncoding.default
             )

--- a/Projects/CoreKit/Sources/Data/Network/Category/CategoryEndpoint.swift
+++ b/Projects/CoreKit/Sources/Data/Network/Category/CategoryEndpoint.swift
@@ -11,8 +11,8 @@ import Util
 import Moya
 /// 카테고리 전용 Endpont
 public enum CategoryEndpoint {
-    case 카테고리_삭제(categoryId: String)
-    case 카테고리_수정(categoryId: String, model: CategoryEditRequest)
+    case 카테고리_삭제(categoryId: Int)
+    case 카테고리_수정(categoryId: Int, model: CategoryEditRequest)
     case 카테고리_목록_조회(model: BasePageableRequest, filterUncategorized: Bool)
     case 카테고리생성(model: CategoryEditRequest)
     case 카테고리_프로필_목록_조회

--- a/Projects/Domain/Sources/CategoryDetail/CategoryDetail.swift
+++ b/Projects/Domain/Sources/CategoryDetail/CategoryDetail.swift
@@ -10,7 +10,7 @@ import Foundation
 public struct CategoryDetail: Equatable {
     // - MARK: Respone
     /// 카테고리(포킷)
-    public let category: BaseCategory
+    public var category: BaseCategory
     /// - 카테고리(포킷) 리스트
     public var categoryListInQuiry: BaseCategoryListInquiry
     /// 카테고리(포킷) 내 콘텐츠(링크) 리스트

--- a/Projects/Domain/Sources/Pokit/Pokit.swift
+++ b/Projects/Domain/Sources/Pokit/Pokit.swift
@@ -17,10 +17,10 @@ public struct Pokit: Equatable {
     public init() {
         self.categoryList = .init(
             data: [],
-            page: 0,
+            page: -1,
             size: 10,
             sort: [],
-            hasNext: false
+            hasNext: true
         )
         self.unclassifiedContentList = .init(
             data: [],

--- a/Projects/Feature/FeatureCategorySetting/Sources/PokitCategorySettingFeature.swift
+++ b/Projects/Feature/FeatureCategorySetting/Sources/PokitCategorySettingFeature.swift
@@ -84,6 +84,7 @@ public struct PokitCategorySettingFeature {
         }
         
         public enum InnerAction: Equatable {
+            case 카테고리_목록_조회_결과(BaseCategoryListInquiry)
             case 프로필_목록_조회_결과(images: [BaseCategoryImage])
         }
         
@@ -185,9 +186,11 @@ private extension PokitCategorySettingFeature {
             }
             
         case .onAppear:
-            // - MARK: 목업 데이터 조회
-            state.domain.categoryListInQuiry = CategoryListInquiryResponse.mock.toDomain()
             return .run { send in
+                let pageRequest = BasePageableRequest(page: 0, size: 100, sort: ["desc"])
+                let response = try await categoryClient.카테고리_목록_조회(pageRequest, true).toDomain()
+                await send(.inner(.카테고리_목록_조회_결과(response)))
+                
                 for await _ in self.pasteboard.changes() {
                     let url = try await pasteboard.probableWebURL()
                     await send(.delegate(.linkCopyDetected(url)), animation: .pokitSpring)
@@ -204,6 +207,9 @@ private extension PokitCategorySettingFeature {
             state.domain.imageList = images
             /// [Profile 🎨] 3. 토글 on
             state.isProfileSheetPresented.toggle()
+            return .none
+        case let .카테고리_목록_조회_결과(response):
+            state.domain.categoryListInQuiry = response
             return .none
         }
     }

--- a/Projects/Feature/FeatureCategorySetting/Sources/PokitCategorySettingView.swift
+++ b/Projects/Feature/FeatureCategorySetting/Sources/PokitCategorySettingView.swift
@@ -48,7 +48,7 @@ public extension PokitCategorySettingView {
                     delegateSend: { store.send(.scope(.profile($0))) }
                 )
             }
-            .onAppear { send(.onAppear) }
+            .task { await send(.onAppear).finish() }
         }
     }
 }

--- a/Projects/Feature/FeatureLogin/Sources/LoginRoot/LoginRootFeature.swift
+++ b/Projects/Feature/FeatureLogin/Sources/LoginRoot/LoginRootFeature.swift
@@ -158,6 +158,7 @@ private extension LoginRootFeature {
         case .registerNickname(let delegate):
             switch delegate {
             case .pushSelectFieldView(let nickname):
+                state.nickName = nickname
                 return .send(.inner(.pushSelectFieldView(nickname: nickname)))
             }
         case .selectField(let delegate):

--- a/Projects/Feature/FeatureLogin/Sources/RegisterNickname/RegisterNicknameFeature.swift
+++ b/Projects/Feature/FeatureLogin/Sources/RegisterNickname/RegisterNicknameFeature.swift
@@ -102,6 +102,7 @@ private extension RegisterNicknameFeature {
         case .backButtonTapped:
             return .run { _ in await self.dismiss() }
         case .binding(\.nicknameText):
+            state.buttonActive = false
             return .run { send in
                 await send(.inner(.textChanged))
             }

--- a/Projects/Feature/FeatureLogin/Sources/RegisterNickname/RegisterNicknameFeature.swift
+++ b/Projects/Feature/FeatureLogin/Sources/RegisterNickname/RegisterNicknameFeature.swift
@@ -98,7 +98,6 @@ private extension RegisterNicknameFeature {
                 return .run { [nickName = state.nicknameText] send in
                     await send(.delegate(.pushSelectFieldView(nickname: nickName)))
                 }
-            return .none
         case .backButtonTapped:
             return .run { _ in await self.dismiss() }
         case .binding(\.nicknameText):

--- a/Projects/Feature/FeaturePokit/Sources/PokitRootView.swift
+++ b/Projects/Feature/FeaturePokit/Sources/PokitRootView.swift
@@ -51,7 +51,7 @@ public extension PokitRootView {
                     delegateSend: { store.send(.scope(.deleteBottomSheet($0))) }
                 )
             }
-            .onAppear { send(.pokitRootViewOnAppeared) }
+            .task { await send(.pokitRootViewOnAppeared).finish() }
         }
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#76 

## 📝작업 내용

- 포킷 플로우에서 카테고리 관련된 모든 API를 연결했습니다.
미분류 카테고리 조회는 서버쪽 작업중이라 아직 미완이고, 링크 추가 / 수정에서의 카테고리 추가 기능같은 경우에는 도형님 작업하실 때 겹쳐지는 화면이다보니 조율이 필요할 것 같아 일단 남겨두겠습니다.
- Response body가 없는 경우가 있더라구요. 제가 깜빡하고 작업을 하지 않아 MoyaProvider+request에 해당 함수 추가해두었습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
도메인쪽 연결을 잘 사용하고 있는지 따끔하게 혼내주세요~~

close #76 
