### PR TITLE
리마인드 플로우 API 연결

### DIFF
--- a/Projects/App/Sources/MainTab/MainTabFeature.swift
+++ b/Projects/App/Sources/MainTab/MainTabFeature.swift
@@ -57,7 +57,7 @@ public struct MainTabFeature {
             case onAppear
         }
         public enum InnerAction: Equatable {
-            case 링크추가및수정이동(contentId: Int)
+            case 링크추가및수정이동(id: Int)
             case linkCopySuccess(URL?)
         }
         public enum AsyncAction: Equatable { case doNothing }

--- a/Projects/App/Sources/MainTab/MainTabFeature.swift
+++ b/Projects/App/Sources/MainTab/MainTabFeature.swift
@@ -57,7 +57,7 @@ public struct MainTabFeature {
             case onAppear
         }
         public enum InnerAction: Equatable {
-            case 링크추가및수정이동(id: Int)
+            case 링크추가및수정이동(contentId: Int)
             case linkCopySuccess(URL?)
         }
         public enum AsyncAction: Equatable { case doNothing }

--- a/Projects/App/Sources/MainTab/MainTabFeature.swift
+++ b/Projects/App/Sources/MainTab/MainTabFeature.swift
@@ -57,7 +57,7 @@ public struct MainTabFeature {
             case onAppear
         }
         public enum InnerAction: Equatable {
-            case 링크추가및수정이동(BaseContent)
+            case 링크추가및수정이동(contentId: Int)
             case linkCopySuccess(URL?)
         }
         public enum AsyncAction: Equatable { case doNothing }

--- a/Projects/App/Sources/MainTab/MainTabPath.swift
+++ b/Projects/App/Sources/MainTab/MainTabPath.swift
@@ -117,14 +117,14 @@ public extension MainTabFeature {
                  let .remind(.delegate(.링크수정(id))),
                  let .path(.element(_, action: .카테고리상세(.delegate(.링크수정(id))))),
                  let .path(.element(_, action: .링크목록(.delegate(.링크수정(id))))):
-                return .run { send in await send(.inner(.링크추가및수정이동(contentId: id))) }
+                return .run { send in await send(.inner(.링크추가및수정이동(id: id))) }
                 
-            case let .contentDetail(.presented(.delegate(.컨텐츠_삭제_완료(contentId: id)))):
+            case let .contentDetail(.presented(.delegate(.컨텐츠_삭제_완료(id: id)))):
                 state.contentDetail = nil
                 // - TODO: 컨텐츠 상세를 띄운 뷰에 컨텐츠 삭제 반영
                 return .none
 
-            case let .inner(.링크추가및수정이동(contentId: id)):
+            case let .inner(.링크추가및수정이동(id: id)):
                 state.path.append(.링크추가및수정(
                     ContentSettingFeature.State(contentId: id)
                 ))

--- a/Projects/App/Sources/MainTab/MainTabPath.swift
+++ b/Projects/App/Sources/MainTab/MainTabPath.swift
@@ -117,14 +117,14 @@ public extension MainTabFeature {
                  let .remind(.delegate(.링크수정(id))),
                  let .path(.element(_, action: .카테고리상세(.delegate(.링크수정(id))))),
                  let .path(.element(_, action: .링크목록(.delegate(.링크수정(id))))):
-                return .run { send in await send(.inner(.링크추가및수정이동(id: id))) }
+                return .run { send in await send(.inner(.링크추가및수정이동(contentId: id))) }
                 
-            case let .contentDetail(.presented(.delegate(.컨텐츠_삭제_완료(id: id)))):
+            case let .contentDetail(.presented(.delegate(.컨텐츠_삭제_완료(contentId: id)))):
                 state.contentDetail = nil
                 // - TODO: 컨텐츠 상세를 띄운 뷰에 컨텐츠 삭제 반영
                 return .none
 
-            case let .inner(.링크추가및수정이동(id: id)):
+            case let .inner(.링크추가및수정이동(contentId: id)):
                 state.path.append(.링크추가및수정(
                     ContentSettingFeature.State(contentId: id)
                 ))

--- a/Projects/App/Sources/MainTab/MainTabPath.swift
+++ b/Projects/App/Sources/MainTab/MainTabPath.swift
@@ -118,6 +118,11 @@ public extension MainTabFeature {
                  let .path(.element(_, action: .카테고리상세(.delegate(.링크수정(id))))),
                  let .path(.element(_, action: .링크목록(.delegate(.링크수정(id))))):
                 return .run { send in await send(.inner(.링크추가및수정이동(contentId: id))) }
+                
+            case let .contentDetail(.presented(.delegate(.컨텐츠_삭제_완료(contentId: id)))):
+                state.contentDetail = nil
+                // - TODO: 컨텐츠 상세를 띄운 뷰에 컨텐츠 삭제 반영
+                return .none
 
             case let .inner(.링크추가및수정이동(contentId: id)):
                 state.path.append(.링크추가및수정(

--- a/Projects/App/Sources/MainTab/MainTabPath.swift
+++ b/Projects/App/Sources/MainTab/MainTabPath.swift
@@ -111,16 +111,16 @@ public extension MainTabFeature {
                 return .none
 
             /// - 링크상세 바텀시트에서 링크수정으로 이동
-            case let .contentDetail(.presented(.delegate(.editButtonTapped(content)))),
-                 let .pokit(.delegate(.링크수정하기(content))),
-                 let .remind(.delegate(.링크수정(content))),
-                 let .path(.element(_, action: .카테고리상세(.delegate(.링크수정(content))))),
-                 let .path(.element(_, action: .링크목록(.delegate(.링크수정(content))))):
-                return .run { send in await send(.inner(.링크추가및수정이동(content))) }
+            case let .contentDetail(.presented(.delegate(.editButtonTapped(id)))),
+                 let .pokit(.delegate(.링크수정하기(id))),
+                 let .remind(.delegate(.링크수정(id))),
+                 let .path(.element(_, action: .카테고리상세(.delegate(.링크수정(id))))),
+                 let .path(.element(_, action: .링크목록(.delegate(.링크수정(id))))):
+                return .run { send in await send(.inner(.링크추가및수정이동(contentId: id))) }
 
-            case let .inner(.링크추가및수정이동(content)):
+            case let .inner(.링크추가및수정이동(contentId: id)):
                 state.path.append(.링크추가및수정(
-                    ContentSettingFeature.State(content: content)
+                    ContentSettingFeature.State(contentId: id)
                 ))
                 state.contentDetail = nil
                 return .none
@@ -131,9 +131,9 @@ public extension MainTabFeature {
                 return .none
 
             /// - 링크추가 및 수정에서 저장하기 눌렀을 때
-            case .path(.element(_, action: .링크추가및수정(.delegate(.저장하기_네트워크이후)))):
+            case .path(.element(_, action: .링크추가및수정(.delegate(.저장하기_완료)))):
                 state.path.removeLast()
-                return .none
+                return .send(.remind(.delegate(.컨텐츠목록_조회)))
             /// - 각 화면에서 링크 복사 감지했을 때 (링크 추가 및 수정 화면 제외)
             case let .path(.element(_, action: .알림함(.delegate(.linkCopyDetected(url))))),
                  let .path(.element(_, action: .검색(.delegate(.linkCopyDetected(url))))),

--- a/Projects/App/Sources/MainTab/MainTabPath.swift
+++ b/Projects/App/Sources/MainTab/MainTabPath.swift
@@ -105,7 +105,8 @@ public extension MainTabFeature {
             /// - 링크 상세
             case let .path(.element(_, action: .카테고리상세(.delegate(.contentItemTapped(content))))),
                  let .pokit(.delegate(.contentDetailTapped(content))),
-                 let .remind(.delegate(.링크상세(content))):
+                 let .remind(.delegate(.링크상세(content))),
+                 let .path(.element(_, action: .링크목록(.delegate(.링크상세(content: content))))):
                 // TODO: 링크상세 모델과 링크수정 모델 일치시키기
                 state.contentDetail = ContentDetailFeature.State(contentId: content.id)
                 return .none

--- a/Projects/CoreKit/Sources/Data/DTO/Base/BaseConditionRequest.swift
+++ b/Projects/CoreKit/Sources/Data/DTO/Base/BaseConditionRequest.swift
@@ -1,0 +1,30 @@
+//
+//  BaseConditionRequest.swift
+//  CoreKit
+//
+//  Created by 김도형 on 8/9/24.
+//
+
+import Foundation
+
+public struct BaseConditionRequest: Decodable {
+    public var categoryIds: [Int]
+    public var isUnreadFiltered: Bool
+    public var isFavoriteFlitered: Bool
+    public var startDate: Date?
+    public var endDate: Date?
+    
+    public init(
+        categoryIds: [Int],
+        isRead: Bool,
+        favorites: Bool,
+        startDate: Date? = nil,
+        endDate: Date? = nil
+    ) {
+        self.categoryIds = categoryIds
+        self.isUnreadFiltered = isRead
+        self.isFavoriteFlitered = favorites
+        self.startDate = startDate
+        self.endDate = endDate
+    }
+}

--- a/Projects/CoreKit/Sources/Data/DTO/Base/ContentBaseRequest.swift
+++ b/Projects/CoreKit/Sources/Data/DTO/Base/ContentBaseRequest.swift
@@ -13,4 +13,18 @@ public struct ContentBaseRequest: Encodable {
     let categoryId: Int
     let memo: String
     let alertYn: String
+    
+    public init(
+        data: String,
+        title: String,
+        categoryId: Int,
+        memo: String,
+        alertYn: String
+    ) {
+        self.data = data
+        self.title = title
+        self.categoryId = categoryId
+        self.memo = memo
+        self.alertYn = alertYn
+    }
 }

--- a/Projects/CoreKit/Sources/Data/DTO/Base/ContentBaseResponse.swift
+++ b/Projects/CoreKit/Sources/Data/DTO/Base/ContentBaseResponse.swift
@@ -9,34 +9,36 @@ import Foundation
 /// 컨텐츠 상세조회, 컨텐츠 수정, 컨텐츠 추가 API Response
 public struct ContentBaseResponse: Decodable {
     public let contentId: Int
-    public let categoryId: Int
-    public let categoryName: String
+    public let category: Category
     public let data: String
     public let domain: String
     public let title: String
     public let thumbNail: String
-    public let memo: String
-    public let alertYn: String
     public let createdAt: String
     public let isRead: Bool
-    public let favorites: Bool
 }
 
 extension ContentBaseResponse {
     public static func mock(id: Int) -> Self {
         Self(
             contentId: id,
-            categoryId: 992,
-            categoryName: "미분류",
+            category: .init(
+                categoryId: 992,
+                categoryName: "미분류"
+            ),
             data: "https://www.youtube.com/watch?v=wtSwdGJzQCQ",
             domain: "youtube",
             title: "신서유기",
             thumbNail: "https://i.ytimg.com/vi/NnOC4_kH0ok/hqdefault.jpg?sqp=-oaymwEjCNACELwBSFryq4qpAxUIARUAAAAAGAElAADIQj0AgKJDeAE=&rs=AOn4CLDN6u6mTjbaVmRZ4biJS_aDq4uvAQ",
-            memo: "#티전드 #신서유기5 #신서유기7 #tvN\n회차정보 : 신서유기5 3회, 신서유기7 1회, 신서유기7 2회, 신서유기7 6회\n\n이제는 전설이 되어버린 역대급 장면들..\n묻지도 따지지도 않고 N회차 재생 가봅시다.",
-            alertYn: "YES",
-            createdAt: "2024-07-31T10:10:23.902Z",
-            isRead: false,
-            favorites: true
+            createdAt: "2024.08.08",
+            isRead: false
         )
+    }
+}
+
+extension ContentBaseResponse {
+    public struct Category: Decodable {
+        public let categoryId: Int
+        public let categoryName: String
     }
 }

--- a/Projects/CoreKit/Sources/Data/DTO/Content/ContentDetailResponse.swift
+++ b/Projects/CoreKit/Sources/Data/DTO/Content/ContentDetailResponse.swift
@@ -13,7 +13,6 @@ public struct ContentDetailResponse: Decodable {
     public let categoryName: String
     public let data: String
     public let title: String
-    public let thumbNail: String
     public let memo: String
     public let alertYn: String
     public let createdAt: String
@@ -27,7 +26,6 @@ extension ContentDetailResponse {
         categoryName: "미분류",
         data: "https://www.youtube.com/watch?v=wtSwdGJzQCQ",
         title: "신서유기",
-        thumbNail: "https://i.ytimg.com/vi/NnOC4_kH0ok/hqdefault.jpg?sqp=-oaymwEjCNACELwBSFryq4qpAxUIARUAAAAAGAElAADIQj0AgKJDeAE=&rs=AOn4CLDN6u6mTjbaVmRZ4biJS_aDq4uvAQ",
         memo: "#티전드 #신서유기5 #신서유기7 #tvN\n회차정보 : 신서유기5 3회, 신서유기7 1회, 신서유기7 2회, 신서유기7 6회\n\n이제는 전설이 되어버린 역대급 장면들..\n묻지도 따지지도 않고 N회차 재생 가봅시다.",
         alertYn: "YES",
         createdAt: "2024-07-31T10:10:23.902Z",

--- a/Projects/CoreKit/Sources/Data/DTO/Content/ContentDetailResponse.swift
+++ b/Projects/CoreKit/Sources/Data/DTO/Content/ContentDetailResponse.swift
@@ -10,7 +10,6 @@ import Foundation
 public struct ContentDetailResponse: Decodable {
     public let contentId: Int
     public let categoryId: Int
-    public let categoryName: String
     public let data: String
     public let title: String
     public let memo: String
@@ -23,7 +22,6 @@ extension ContentDetailResponse {
     public static var mock: Self = Self(
         contentId: 512,
         categoryId: 992,
-        categoryName: "미분류",
         data: "https://www.youtube.com/watch?v=wtSwdGJzQCQ",
         title: "신서유기",
         memo: "#티전드 #신서유기5 #신서유기7 #tvN\n회차정보 : 신서유기5 3회, 신서유기7 1회, 신서유기7 2회, 신서유기7 6회\n\n이제는 전설이 되어버린 역대급 장면들..\n묻지도 따지지도 않고 N회차 재생 가봅시다.",

--- a/Projects/CoreKit/Sources/Data/Network/Category/CategoryClient.swift
+++ b/Projects/CoreKit/Sources/Data/Network/Category/CategoryClient.swift
@@ -31,6 +31,9 @@ public struct CategoryClient {
 ) async throws -> [CategoryImageResponse]
     public var 유저_카테고리_개수_조회: @Sendable (
     ) async throws -> CategoryCountResponse
+    public var 카테고리_상세_조회: @Sendable (
+        _ categoryId: String
+    ) async throws -> CategoryEditResponse
 }
 
 extension CategoryClient: DependencyKey {
@@ -55,6 +58,9 @@ extension CategoryClient: DependencyKey {
             },
             유저_카테고리_개수_조회: {
                 try await provider.request(.유저_카테고리_개수_조회)
+            },
+            카테고리_상세_조회: { id in
+                try await provider.request(.카테고리_상세_조회(categoryId: id))
             }
         )
     }()
@@ -66,7 +72,8 @@ extension CategoryClient: DependencyKey {
             카테고리_목록_조회: { _, _ in .mock },
             카테고리_생성: { _ in .mock },
             카테고리_프로필_목록_조회: { CategoryImageResponse.mock },
-            유저_카테고리_개수_조회: { .mock }
+            유저_카테고리_개수_조회: { .mock },
+            카테고리_상세_조회: { _ in .mock }
         )
     }()
 }

--- a/Projects/CoreKit/Sources/Data/Network/Category/CategoryEndpoint.swift
+++ b/Projects/CoreKit/Sources/Data/Network/Category/CategoryEndpoint.swift
@@ -17,6 +17,7 @@ public enum CategoryEndpoint {
     case 카테고리생성(model: CategoryEditRequest)
     case 카테고리_프로필_목록_조회
     case 유저_카테고리_개수_조회
+    case 카테고리_상세_조회(categoryId: String)
     
 }
 
@@ -38,6 +39,8 @@ extension CategoryEndpoint: TargetType {
         case .카테고리_목록_조회,
              .카테고리생성:
             return ""
+        case .카테고리_상세_조회(let categoryId):
+            return "/\(categoryId)"
         }
     }
     
@@ -51,7 +54,8 @@ extension CategoryEndpoint: TargetType {
             
         case .카테고리_목록_조회,
              .카테고리_프로필_목록_조회,
-             .유저_카테고리_개수_조회: 
+             .유저_카테고리_개수_조회,
+             .카테고리_상세_조회:
             return .get
             
         case .카테고리생성:
@@ -80,6 +84,8 @@ extension CategoryEndpoint: TargetType {
         case .카테고리_프로필_목록_조회:
             return .requestPlain
         case .유저_카테고리_개수_조회:
+            return .requestPlain
+        case .카테고리_상세_조회:
             return .requestPlain
         }
     }

--- a/Projects/CoreKit/Sources/Data/Network/Content/ContentClient.swift
+++ b/Projects/CoreKit/Sources/Data/Network/Content/ContentClient.swift
@@ -18,27 +18,26 @@ extension DependencyValues {
 }
 /// Category에 관련한 API를 처리하는 Client
 public struct ContentClient {
-    var 컨텐츠_삭제: @Sendable (
+    public var 컨텐츠_삭제: @Sendable (
         _ categoryId: String
     ) async throws -> EmptyResponse
-    var 컨텐츠_상세_조회: @Sendable (
+    public var 컨텐츠_상세_조회: @Sendable (
+        _ contentId: String
+    ) async throws -> ContentDetailResponse
+    public var 컨텐츠_수정: @Sendable (
         _ contentId: String,
         _ model: ContentBaseRequest
     ) async throws -> ContentBaseResponse
-    var 컨텐츠_수정: @Sendable (
-        _ contentId: String, 
+    public var 컨텐츠_추가: @Sendable (
         _ model: ContentBaseRequest
     ) async throws -> ContentBaseResponse
-    var 컨텐츠_추가: @Sendable (
-        _ model: ContentBaseRequest
-    ) async throws -> ContentBaseResponse
-    var 즐겨찾기: @Sendable (
+    public var 즐겨찾기: @Sendable (
         _ contentId: String
     ) async throws -> BookmarkResponse
-    var 즐겨찾기_취소: @Sendable (
+    public var 즐겨찾기_취소: @Sendable (
         _ contentId: String
     ) async throws -> EmptyResponse
-    var 카테고리_내_컨텐츠_목록_조회: @Sendable (
+    public var 카테고리_내_컨텐츠_목록_조회: @Sendable (
         _ contentId: String,
         _ model: BasePageableRequest
     ) async throws -> ContentListInquiryResponse
@@ -52,8 +51,8 @@ extension ContentClient: DependencyKey {
             컨텐츠_삭제: { id in
                 try await provider.request(.컨텐츠_삭제(contentId: id))
             },
-            컨텐츠_상세_조회: { id, model in
-                try await provider.request(.컨텐츠_상세_조회(contentId: id, model: model))
+            컨텐츠_상세_조회: { id in
+                try await provider.request(.컨텐츠_상세_조회(contentId: id))
             },
             컨텐츠_수정: { id, model in
                 try await provider.request(.컨텐츠_수정(contentId: id, model: model))
@@ -76,7 +75,7 @@ extension ContentClient: DependencyKey {
     public static let previewValue: Self = {
         Self(
             컨텐츠_삭제: { _ in .init() },
-            컨텐츠_상세_조회: { _, _ in .mock(id: 0) },
+            컨텐츠_상세_조회: { _ in .mock },
             컨텐츠_수정: { _, _ in .mock(id: 0) },
             컨텐츠_추가: { _ in .mock(id: 0) },
             즐겨찾기: { _ in .mock },

--- a/Projects/CoreKit/Sources/Data/Network/Content/ContentClient.swift
+++ b/Projects/CoreKit/Sources/Data/Network/Content/ContentClient.swift
@@ -27,10 +27,10 @@ public struct ContentClient {
     public var 컨텐츠_수정: @Sendable (
         _ contentId: String,
         _ model: ContentBaseRequest
-    ) async throws -> ContentBaseResponse
+    ) async throws -> ContentDetailResponse
     public var 컨텐츠_추가: @Sendable (
         _ model: ContentBaseRequest
-    ) async throws -> ContentBaseResponse
+    ) async throws -> ContentDetailResponse
     public var 즐겨찾기: @Sendable (
         _ contentId: String
     ) async throws -> BookmarkResponse
@@ -76,8 +76,8 @@ extension ContentClient: DependencyKey {
         Self(
             컨텐츠_삭제: { _ in .init() },
             컨텐츠_상세_조회: { _ in .mock },
-            컨텐츠_수정: { _, _ in .mock(id: 0) },
-            컨텐츠_추가: { _ in .mock(id: 0) },
+            컨텐츠_수정: { _, _ in .mock },
+            컨텐츠_추가: { _ in .mock },
             즐겨찾기: { _ in .mock },
             즐겨찾기_취소: { _ in .init() },
             카테고리_내_컨텐츠_목록_조회: { _, _ in .mock }

--- a/Projects/CoreKit/Sources/Data/Network/Content/ContentClient.swift
+++ b/Projects/CoreKit/Sources/Data/Network/Content/ContentClient.swift
@@ -50,7 +50,7 @@ public struct ContentClient {
 extension ContentClient: DependencyKey {
     public static let liveValue: Self = {
         let provider = MoyaProvider<ContentEndpoint>.build()
-
+        
         return Self(
             컨텐츠_삭제: { id in
                 try await provider.requestNoBody(.컨텐츠_삭제(contentId: id))
@@ -71,11 +71,13 @@ extension ContentClient: DependencyKey {
                 try await provider.request(.즐겨찾기_취소(contentId: id))
             },
             카테고리_내_컨텐츠_목록_조회: { id, pageable, condition in
-                try await provider.request(.카태고리_내_컨텐츠_목록_조회(
-                    contentId: id,
-                    pageable: pageable,
-                    condition: condition
-                ))
+                try await provider.request(
+                    .카태고리_내_컨텐츠_목록_조회(
+                        contentId: id,
+                        pageable: pageable,
+                        condition: condition
+                    )
+                )
             },
             미분류_카테고리_컨텐츠_조회: { model in
                 try await provider.request(.미분류_카테고리_컨텐츠_조회(model: model))

--- a/Projects/CoreKit/Sources/Data/Network/Content/ContentClient.swift
+++ b/Projects/CoreKit/Sources/Data/Network/Content/ContentClient.swift
@@ -20,7 +20,7 @@ extension DependencyValues {
 public struct ContentClient {
     public var 컨텐츠_삭제: @Sendable (
         _ categoryId: String
-    ) async throws -> EmptyResponse
+    ) async throws -> Void
     public var 컨텐츠_상세_조회: @Sendable (
         _ contentId: String
     ) async throws -> ContentDetailResponse
@@ -53,7 +53,7 @@ extension ContentClient: DependencyKey {
 
         return Self(
             컨텐츠_삭제: { id in
-                try await provider.request(.컨텐츠_삭제(contentId: id))
+                try await provider.requestNoBody(.컨텐츠_삭제(contentId: id))
             },
             컨텐츠_상세_조회: { id in
                 try await provider.request(.컨텐츠_상세_조회(contentId: id))
@@ -85,7 +85,7 @@ extension ContentClient: DependencyKey {
 
     public static let previewValue: Self = {
         Self(
-            컨텐츠_삭제: { _ in .init() },
+            컨텐츠_삭제: { _ in },
             컨텐츠_상세_조회: { _ in .mock },
             컨텐츠_수정: { _, _ in .mock },
             컨텐츠_추가: { _ in .mock },

--- a/Projects/CoreKit/Sources/Data/Network/Content/ContentClient.swift
+++ b/Projects/CoreKit/Sources/Data/Network/Content/ContentClient.swift
@@ -39,7 +39,8 @@ public struct ContentClient {
     ) async throws -> EmptyResponse
     public var 카테고리_내_컨텐츠_목록_조회: @Sendable (
         _ contentId: String,
-        _ model: BasePageableRequest
+        _ pageable: BasePageableRequest,
+        _ condition: BaseConditionRequest
     ) async throws -> ContentListInquiryResponse
 }
 
@@ -66,8 +67,12 @@ extension ContentClient: DependencyKey {
             즐겨찾기_취소: { id in
                 try await provider.request(.즐겨찾기_취소(contentId: id))
             },
-            카테고리_내_컨텐츠_목록_조회: { id, model in
-                try await provider.request(.카태고리_내_컨텐츠_목록_조회(contentId: id, model: model))
+            카테고리_내_컨텐츠_목록_조회: { id, pageable, condition in
+                try await provider.request(.카태고리_내_컨텐츠_목록_조회(
+                    contentId: id,
+                    pageable: pageable,
+                    condition: condition
+                ))
             }
         )
     }()
@@ -80,7 +85,7 @@ extension ContentClient: DependencyKey {
             컨텐츠_추가: { _ in .mock },
             즐겨찾기: { _ in .mock },
             즐겨찾기_취소: { _ in .init() },
-            카테고리_내_컨텐츠_목록_조회: { _, _ in .mock }
+            카테고리_내_컨텐츠_목록_조회: { _, _, _ in .mock }
         )
     }()
 }

--- a/Projects/CoreKit/Sources/Data/Network/Content/ContentClient.swift
+++ b/Projects/CoreKit/Sources/Data/Network/Content/ContentClient.swift
@@ -42,6 +42,9 @@ public struct ContentClient {
         _ pageable: BasePageableRequest,
         _ condition: BaseConditionRequest
     ) async throws -> ContentListInquiryResponse
+    public var 미분류_카테고리_컨텐츠_조회: @Sendable (
+        _ model: BasePageableRequest
+    ) async throws -> ContentListInquiryResponse
 }
 
 extension ContentClient: DependencyKey {
@@ -73,6 +76,9 @@ extension ContentClient: DependencyKey {
                     pageable: pageable,
                     condition: condition
                 ))
+            },
+            미분류_카테고리_컨텐츠_조회: { model in
+                try await provider.request(.미분류_카테고리_컨텐츠_조회(model: model))
             }
         )
     }()
@@ -85,7 +91,8 @@ extension ContentClient: DependencyKey {
             컨텐츠_추가: { _ in .mock },
             즐겨찾기: { _ in .mock },
             즐겨찾기_취소: { _ in .init() },
-            카테고리_내_컨텐츠_목록_조회: { _, _, _ in .mock }
+            카테고리_내_컨텐츠_목록_조회: { _, _, _ in .mock },
+            미분류_카테고리_컨텐츠_조회: { _ in .mock }
         )
     }()
 }

--- a/Projects/CoreKit/Sources/Data/Network/Content/ContentEndpoint.swift
+++ b/Projects/CoreKit/Sources/Data/Network/Content/ContentEndpoint.swift
@@ -17,7 +17,11 @@ public enum ContentEndpoint {
     case 즐겨찾기_취소(contentId: String)
     case 즐겨찾기(contentId: String)
     case 컨텐츠_추가(model: ContentBaseRequest)
-    case 카태고리_내_컨텐츠_목록_조회(contentId: String, model: BasePageableRequest)
+    case 카태고리_내_컨텐츠_목록_조회(
+        contentId: String,
+        pageable: BasePageableRequest,
+        condition: BaseConditionRequest
+    )
 }
 
 extension ContentEndpoint: TargetType {
@@ -39,7 +43,7 @@ extension ContentEndpoint: TargetType {
             return "/\(contentId)/bookmark"
         case .컨텐츠_추가:
             return ""
-        case let .카태고리_내_컨텐츠_목록_조회(contentId, _):
+        case let .카태고리_내_컨텐츠_목록_조회(contentId, _, _):
             return "/\(contentId)"
         }
     }
@@ -77,12 +81,17 @@ extension ContentEndpoint: TargetType {
             return .requestPlain
         case let .컨텐츠_추가(model):
             return .requestJSONEncodable(model)
-        case let .카태고리_내_컨텐츠_목록_조회(_, model):
+        case let .카태고리_내_컨텐츠_목록_조회(id, pageable, condition):
             return .requestParameters(
                 parameters: [
-                    "page": model.page,
-                    "size": model.size,
-                    "sort": model.sort
+                    "page": pageable.page,
+                    "size": pageable.size,
+                    "sort": pageable.sort,
+                    "isRead": condition.isUnreadFiltered ? condition.isUnreadFiltered : "",
+                    "favorites": condition.isFavoriteFlitered ? condition.isFavoriteFlitered : "",
+                    "startDate": condition.startDate ?? "",
+                    "endDate": condition.endDate ?? "",
+                    "categoryIds": condition.categoryIds
                 ],
                 encoding: URLEncoding.default
             )

--- a/Projects/CoreKit/Sources/Data/Network/Content/ContentEndpoint.swift
+++ b/Projects/CoreKit/Sources/Data/Network/Content/ContentEndpoint.swift
@@ -12,7 +12,7 @@ import Moya
 /// 컨텐츠 전용 Endpont
 public enum ContentEndpoint {
     case 컨텐츠_삭제(contentId: String)
-    case 컨텐츠_상세_조회(contentId: String, model: ContentBaseRequest)
+    case 컨텐츠_상세_조회(contentId: String)
     case 컨텐츠_수정(contentId: String, model: ContentBaseRequest)
     case 즐겨찾기_취소(contentId: String)
     case 즐겨찾기(contentId: String)
@@ -29,7 +29,7 @@ extension ContentEndpoint: TargetType {
         switch self {
         case let .컨텐츠_삭제(categoryId):
             return "/\(categoryId)"
-        case let .컨텐츠_상세_조회(contentId, _):
+        case let .컨텐츠_상세_조회(contentId):
             return "/\(contentId)"
         case let .컨텐츠_수정(contentId, _):
             return "/\(contentId)"
@@ -67,8 +67,8 @@ extension ContentEndpoint: TargetType {
         switch self {
         case .컨텐츠_삭제:
             return .requestPlain
-        case let .컨텐츠_상세_조회(_, model):
-            return .requestJSONEncodable(model)
+        case .컨텐츠_상세_조회:
+            return .requestPlain
         case let .컨텐츠_수정(_, model):
             return .requestJSONEncodable(model)
         case .즐겨찾기_취소:

--- a/Projects/CoreKit/Sources/Data/Network/Content/ContentEndpoint.swift
+++ b/Projects/CoreKit/Sources/Data/Network/Content/ContentEndpoint.swift
@@ -22,6 +22,7 @@ public enum ContentEndpoint {
         pageable: BasePageableRequest,
         condition: BaseConditionRequest
     )
+    case 미분류_카테고리_컨텐츠_조회(model: BasePageableRequest)
 }
 
 extension ContentEndpoint: TargetType {
@@ -45,6 +46,8 @@ extension ContentEndpoint: TargetType {
             return ""
         case let .카태고리_내_컨텐츠_목록_조회(contentId, _, _):
             return "/\(contentId)"
+        case .미분류_카테고리_컨텐츠_조회:
+            return "/uncategorized"
         }
     }
     
@@ -62,7 +65,8 @@ extension ContentEndpoint: TargetType {
         case .컨텐츠_수정:
             return .patch
             
-        case .카태고리_내_컨텐츠_목록_조회:
+        case .카태고리_내_컨텐츠_목록_조회,
+             .미분류_카테고리_컨텐츠_조회:
             return .get
         }
     }
@@ -92,6 +96,15 @@ extension ContentEndpoint: TargetType {
                     "startDate": condition.startDate ?? "",
                     "endDate": condition.endDate ?? "",
                     "categoryIds": condition.categoryIds
+                ],
+                encoding: URLEncoding.default
+            )
+        case let .미분류_카테고리_컨텐츠_조회(model):
+            return .requestParameters(
+                parameters: [
+                    "page": model.page,
+                    "size": model.size,
+                    "sort": model.sort
                 ],
                 encoding: URLEncoding.default
             )

--- a/Projects/CoreKit/Sources/Data/Network/Remind/RemindClient.swift
+++ b/Projects/CoreKit/Sources/Data/Network/Remind/RemindClient.swift
@@ -1,0 +1,55 @@
+//
+//  RemindClient.swift
+//  CoreKit
+//
+//  Created by 김도형 on 8/8/24.
+//
+
+import Foundation
+
+import Dependencies
+import Moya
+
+public struct RemindClient {
+    public var 오늘의_리마인드_조회: @Sendable ()
+    async throws -> [ContentBaseResponse]
+    public var 읽지않음_컨텐츠_조회: @Sendable (
+        _ model: BasePageableRequest
+    ) async throws -> ContentListInquiryResponse
+    public var 즐겨찾기_링크모음_조회: @Sendable (
+        _ model: BasePageableRequest
+    ) async throws -> ContentListInquiryResponse
+}
+
+extension RemindClient: DependencyKey {
+    public static let liveValue: Self = {
+        let provider = MoyaProvider<RemindEndpoint>.build()
+        
+        return .init(
+            오늘의_리마인드_조회: {
+                try await provider.request(.오늘의_리마인드_조회)
+            },
+            읽지않음_컨텐츠_조회: { model in
+                try await provider.request(.읽지않음_컨텐츠_조회(model: model))
+            },
+            즐겨찾기_링크모음_조회: { model in
+                try await provider.request(.즐겨찾기_링크모음_조회(model: model))
+            }
+        )
+    }()
+    
+    public static let previewValue: Self = {
+        .init(
+            오늘의_리마인드_조회: { [.mock(id: 0), .mock(id: 1), .mock(id: 2)]},
+            읽지않음_컨텐츠_조회: { _ in .mock },
+            즐겨찾기_링크모음_조회: { _ in .mock }
+        )
+    }()
+}
+
+extension DependencyValues {
+    public var remindClient: RemindClient {
+        get { self[RemindClient.self] }
+        set { self[RemindClient.self] = newValue }
+    }
+}

--- a/Projects/CoreKit/Sources/Data/Network/Remind/RemindEndpoint.swift
+++ b/Projects/CoreKit/Sources/Data/Network/Remind/RemindEndpoint.swift
@@ -49,7 +49,14 @@ extension RemindEndpoint: TargetType {
             return .requestPlain
         case .읽지않음_컨텐츠_조회(let model),
              .즐겨찾기_링크모음_조회(let model):
-            return .requestJSONEncodable(model)
+            return .requestParameters(
+                parameters: [
+                    "page": model.page,
+                    "size": model.size,
+                    "sort": model.sort
+                ],
+                encoding: URLEncoding.default
+            )
         }
     }
     

--- a/Projects/CoreKit/Sources/Data/Network/Remind/RemindEndpoint.swift
+++ b/Projects/CoreKit/Sources/Data/Network/Remind/RemindEndpoint.swift
@@ -1,0 +1,59 @@
+//
+//  RemindEndpoint.swift
+//  CoreKit
+//
+//  Created by 김도형 on 8/8/24.
+//
+
+import Foundation
+
+import Util
+import Moya
+
+public enum RemindEndpoint {
+    case 오늘의_리마인드_조회
+    case 읽지않음_컨텐츠_조회(model: BasePageableRequest)
+    case 즐겨찾기_링크모음_조회(model: BasePageableRequest)
+}
+
+extension RemindEndpoint: TargetType {
+    public var baseURL: URL {
+        Constants
+            .serverURL
+            .appendingPathComponent(
+                Constants.remindPath,
+                conformingTo: .url
+            )
+    }
+    
+    public var path: String {
+        switch self {
+        case .오늘의_리마인드_조회: return "/today"
+        case .읽지않음_컨텐츠_조회(_): return "/unread"
+        case .즐겨찾기_링크모음_조회(_): return "/bookmark"
+        }
+    }
+    
+    public var method: Moya.Method {
+        switch self {
+        case .오늘의_리마인드_조회,
+             .읽지않음_컨텐츠_조회,
+             .즐겨찾기_링크모음_조회:
+            return .get
+        }
+    }
+    
+    public var task: Moya.Task {
+        switch self {
+        case .오늘의_리마인드_조회:
+            return .requestPlain
+        case .읽지않음_컨텐츠_조회(let model),
+             .즐겨찾기_링크모음_조회(let model):
+            return .requestJSONEncodable(model)
+        }
+    }
+    
+    public var headers: [String : String]? {
+        ["Content-Type": "application/json"]
+    }
+}

--- a/Projects/DSKit/Sources/Components/PokitLinkCard.swift
+++ b/Projects/DSKit/Sources/Components/PokitLinkCard.swift
@@ -103,6 +103,7 @@ public struct PokitLinkCard<Item: PokitLinkCardItem>: View {
         AsyncImage(url: .init(string: link.thumbNail)) { image in
             image
                 .resizable()
+                .aspectRatio(contentMode: .fill)
         } placeholder: {
             Color.pokit(.bg(.disable))
         }

--- a/Projects/DSKit/Sources/Components/PokitLinkCard.swift
+++ b/Projects/DSKit/Sources/Components/PokitLinkCard.swift
@@ -68,7 +68,7 @@ public struct PokitLinkCard<Item: PokitLinkCardItem>: View {
     }
     
     private var subTitle: some View {
-        Text("\(date) • \(link.domain)")
+        Text("\(link.createdAt) • \(link.domain)")
             .pokitFont(.detail2)
             .foregroundStyle(.pokit(.text(.tertiary)))
             .multilineTextAlignment(.leading)
@@ -108,12 +108,6 @@ public struct PokitLinkCard<Item: PokitLinkCardItem>: View {
         }
         .frame(width: 124, height: 94)
         .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-    }
-    
-    private var date: String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy.MM.dd"
-        return formatter.string(from: link.createdAt)
     }
     
     private var divider: some View {

--- a/Projects/Domain/Sources/Base/BaseCategory.swift
+++ b/Projects/Domain/Sources/Base/BaseCategory.swift
@@ -9,7 +9,7 @@ import Foundation
 
 import CoreKit
 
-public struct BaseCategoryDetail: Equatable {
+public struct BaseCategory: Equatable {
     public let categoryId: Int
     public let categoryName: String
     public let categoryImage: BaseCategoryImage

--- a/Projects/Domain/Sources/Base/BaseCategoryDetail.swift
+++ b/Projects/Domain/Sources/Base/BaseCategoryDetail.swift
@@ -1,0 +1,26 @@
+//
+//  BaseCategoryDetail.swift
+//  Domain
+//
+//  Created by 김도형 on 8/8/24.
+//
+
+import Foundation
+
+import CoreKit
+
+public struct BaseCategoryDetail: Equatable {
+    public let categoryId: Int
+    public let categoryName: String
+    public let categoryImage: BaseCategoryImage
+    
+    public init(
+        categoryId: Int,
+        categoryName: String,
+        categoryImage: BaseCategoryImage
+    ) {
+        self.categoryId = categoryId
+        self.categoryName = categoryName
+        self.categoryImage = categoryImage
+    }
+}

--- a/Projects/Domain/Sources/Base/BaseCategoryItem.swift
+++ b/Projects/Domain/Sources/Base/BaseCategoryItem.swift
@@ -9,7 +9,7 @@ import Foundation
 
 import Util
 
-public struct BaseCategory: Identifiable, Equatable, PokitSelectItem, PokitCardItem {
+public struct BaseCategoryItem: Identifiable, Equatable, PokitSelectItem, PokitCardItem {
     public let id: Int
     public let userId: Int
     public let categoryName: String

--- a/Projects/Domain/Sources/Base/BaseCategoryListInquiry.swift
+++ b/Projects/Domain/Sources/Base/BaseCategoryListInquiry.swift
@@ -8,14 +8,14 @@
 import Foundation
 
 public struct BaseCategoryListInquiry: Equatable {
-    public var data: [BaseCategory]
+    public var data: [BaseCategoryItem]
     public var page: Int
     public var size: Int
     public var sort: [BaseItemInquirySort]
     public var hasNext: Bool
     
     public init(
-        data: [BaseCategory],
+        data: [BaseCategoryItem],
         page: Int,
         size: Int,
         sort: [BaseItemInquirySort],

--- a/Projects/Domain/Sources/Base/BaseCondition.swift
+++ b/Projects/Domain/Sources/Base/BaseCondition.swift
@@ -1,0 +1,16 @@
+//
+//  BaseCondition.swift
+//  Domain
+//
+//  Created by 김도형 on 8/9/24.
+//
+
+import Foundation
+
+public struct BaseCondition: Equatable {
+    public var categoryIds: [Int]
+    public var isUnreadFlitered: Bool
+    public var isFavoriteFlitered: Bool
+    public var startDate: Date?
+    public var endDate: Date?
+}

--- a/Projects/Domain/Sources/Base/BaseContent.swift
+++ b/Projects/Domain/Sources/Base/BaseContent.swift
@@ -17,7 +17,7 @@ public struct BaseContent: Identifiable, Equatable, PokitLinkCardItem {
     public let thumbNail: String
     public let data: String
     public let domain: String
-    public let createdAt: Date
+    public let createdAt: String
     public let isRead: Bool
     
     public init(
@@ -28,7 +28,7 @@ public struct BaseContent: Identifiable, Equatable, PokitLinkCardItem {
         thumbNail: String,
         data: String,
         domain: String,
-        createdAt: Date,
+        createdAt: String,
         isRead: Bool
     ) {
         self.id = id

--- a/Projects/Domain/Sources/Base/BaseContent.swift
+++ b/Projects/Domain/Sources/Base/BaseContent.swift
@@ -10,33 +10,26 @@ import Foundation
 import Util
 
 public struct BaseContent: Identifiable, Equatable, PokitLinkCardItem {
-    
     public let id: Int
     public let categoryName: String
-    public let categoryId: Int?
+    public let categoryId: Int
     public let title: String
     public let thumbNail: String
     public let data: String
     public let domain: String
-    public let memo: String
     public let createdAt: Date
     public let isRead: Bool
-    public let favorites: Bool
-    public let alertYn: RemindState
     
     public init(
         id: Int,
         categoryName: String,
-        categoryId: Int?,
+        categoryId: Int,
         title: String,
         thumbNail: String,
         data: String,
         domain: String,
-        memo: String,
         createdAt: Date,
-        isRead: Bool,
-        favorites: Bool,
-        alertYn: RemindState
+        isRead: Bool
     ) {
         self.id = id
         self.categoryName = categoryName
@@ -45,17 +38,7 @@ public struct BaseContent: Identifiable, Equatable, PokitLinkCardItem {
         self.thumbNail = thumbNail
         self.data = data
         self.domain = domain
-        self.memo = memo
         self.createdAt = createdAt
         self.isRead = isRead
-        self.favorites = favorites
-        self.alertYn = alertYn
-    }
-}
-
-public extension BaseContent {
-    enum RemindState: String, Equatable {
-        case yes = "YES"
-        case no = "NO"
     }
 }

--- a/Projects/Domain/Sources/Base/BaseContentDetail.swift
+++ b/Projects/Domain/Sources/Base/BaseContentDetail.swift
@@ -1,0 +1,46 @@
+//
+//  BaseContentDetail.swift
+//  Domain
+//
+//  Created by 김도형 on 8/9/24.
+//
+
+import Foundation
+
+public struct BaseContentDetail: Equatable {
+    public let id: Int
+    public let categoryId: Int
+    public let title: String
+    public let data: String
+    public let memo: String
+    public let createdAt: Date
+    public var favorites: Bool
+    public var alertYn: RemindState
+    
+    public init(
+        id: Int,
+        categoryId: Int,
+        title: String,
+        data: String,
+        memo: String,
+        createdAt: Date,
+        favorites: Bool,
+        alertYn: RemindState
+    ) {
+        self.id = id
+        self.categoryId = categoryId
+        self.title = title
+        self.data = data
+        self.memo = memo
+        self.createdAt = createdAt
+        self.favorites = favorites
+        self.alertYn = alertYn
+    }
+}
+
+public extension BaseContentDetail {
+    enum RemindState: String, Equatable {
+        case yes = "YES"
+        case no = "NO"
+    }
+}

--- a/Projects/Domain/Sources/Base/BaseContentItem.swift
+++ b/Projects/Domain/Sources/Base/BaseContentItem.swift
@@ -9,7 +9,7 @@ import Foundation
 
 import Util
 
-public struct BaseContent: Identifiable, Equatable, PokitLinkCardItem {
+public struct BaseContentItem: Identifiable, Equatable, PokitLinkCardItem {
     public let id: Int
     public let categoryName: String
     public let categoryId: Int

--- a/Projects/Domain/Sources/Base/BaseContentListInquiry.swift
+++ b/Projects/Domain/Sources/Base/BaseContentListInquiry.swift
@@ -8,14 +8,14 @@
 import Foundation
 
 public struct BaseContentListInquiry: Equatable {
-    public var data: [BaseContent]
+    public var data: [BaseContentItem]
     public var page: Int
     public var size: Int
     public var sort: [BaseItemInquirySort]
     public var hasNext: Bool
     
     public init(
-        data: [BaseContent],
+        data: [BaseContentItem],
         page: Int,
         size: Int,
         sort: [BaseItemInquirySort],

--- a/Projects/Domain/Sources/Base/BasePageable.swift
+++ b/Projects/Domain/Sources/Base/BasePageable.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public struct BasePageable: Equatable {
-    public let page: Int
-    public let size: Int
-    public let sort: [String]
+    public var page: Int
+    public var size: Int
+    public var sort: [String]
 }

--- a/Projects/Domain/Sources/CategoryDetail/CategoryDetail.swift
+++ b/Projects/Domain/Sources/CategoryDetail/CategoryDetail.swift
@@ -18,6 +18,8 @@ public struct CategoryDetail: Equatable {
     // - MARK: Request
     /// 조회할 페이징 정보
     public var pageable: BasePageable
+    /// - 조회 필터
+    public var condition: BaseCondition
     
     public init(categpry: BaseCategory) {
         self.category = categpry
@@ -39,7 +41,12 @@ public struct CategoryDetail: Equatable {
         self.pageable = .init(
             page: 0,
             size: 10,
-            sort: []
+            sort: ["desc"]
+        )
+        self.condition = .init(
+            categoryIds: [],
+            isUnreadFlitered: false,
+            isFavoriteFlitered: false
         )
     }
 }

--- a/Projects/Domain/Sources/CategoryDetail/CategoryDetail.swift
+++ b/Projects/Domain/Sources/CategoryDetail/CategoryDetail.swift
@@ -10,7 +10,7 @@ import Foundation
 public struct CategoryDetail: Equatable {
     // - MARK: Respone
     /// 카테고리(포킷)
-    public var category: BaseCategory
+    public var category: BaseCategoryItem
     /// - 카테고리(포킷) 리스트
     public var categoryListInQuiry: BaseCategoryListInquiry
     /// 카테고리(포킷) 내 콘텐츠(링크) 리스트
@@ -21,7 +21,7 @@ public struct CategoryDetail: Equatable {
     /// - 조회 필터
     public var condition: BaseCondition
     
-    public init(categpry: BaseCategory) {
+    public init(categpry: BaseCategoryItem) {
         self.category = categpry
         let categoryListInquiry = BaseCategoryListInquiry(
             data: [],

--- a/Projects/Domain/Sources/ContentDetail/ContentDetail.swift
+++ b/Projects/Domain/Sources/ContentDetail/ContentDetail.swift
@@ -34,7 +34,7 @@ public extension ContentDetail {
         public let memo: String
         public let createdAt: Date
         public var favorites: Bool
-        public var alertYn: BaseContent.RemindState
+        public var alertYn: RemindState
         
         public init(
             id: Int,
@@ -45,7 +45,7 @@ public extension ContentDetail {
             memo: String,
             createdAt: Date,
             favorites: Bool,
-            alertYn: BaseContent.RemindState
+            alertYn: RemindState
         ) {
             self.id = id
             self.categoryName = categoryName
@@ -57,5 +57,12 @@ public extension ContentDetail {
             self.favorites = favorites
             self.alertYn = alertYn
         }
+    }
+}
+
+public extension ContentDetail.Content {
+    enum RemindState: String, Equatable {
+        case yes = "YES"
+        case no = "NO"
     }
 }

--- a/Projects/Domain/Sources/ContentDetail/ContentDetail.swift
+++ b/Projects/Domain/Sources/ContentDetail/ContentDetail.swift
@@ -11,7 +11,7 @@ public struct ContentDetail: Equatable {
     // - MARK: Response
     /// 콘텐츠(링크) 상세
     public var content: BaseContentDetail?
-    public var category: BaseCategoryDetail?
+    public var category: BaseCategory?
     // - MARK: Request
     /// 조회할 콘텐츠 id
     public let contentId: Int

--- a/Projects/Domain/Sources/ContentDetail/ContentDetail.swift
+++ b/Projects/Domain/Sources/ContentDetail/ContentDetail.swift
@@ -30,7 +30,6 @@ public extension ContentDetail {
         public let categoryName: String
         public let categoryId: Int?
         public let title: String
-        public let thumbNail: String
         public let data: String
         public let memo: String
         public let createdAt: Date
@@ -42,7 +41,6 @@ public extension ContentDetail {
             categoryName: String,
             categoryId: Int?,
             title: String,
-            thumbNail: String,
             data: String,
             memo: String,
             createdAt: Date,
@@ -53,7 +51,6 @@ public extension ContentDetail {
             self.categoryName = categoryName
             self.categoryId = categoryId
             self.title = title
-            self.thumbNail = thumbNail
             self.data = data
             self.memo = memo
             self.createdAt = createdAt

--- a/Projects/Domain/Sources/ContentDetail/ContentDetail.swift
+++ b/Projects/Domain/Sources/ContentDetail/ContentDetail.swift
@@ -11,6 +11,7 @@ public struct ContentDetail: Equatable {
     // - MARK: Response
     /// 콘텐츠(링크) 상세
     public var content: ContentDetail.Content?
+    public var category: BaseCategoryDetail?
     // - MARK: Request
     /// 조회할 콘텐츠 id
     public let contentId: Int
@@ -27,8 +28,7 @@ public struct ContentDetail: Equatable {
 public extension ContentDetail {
     struct Content: Equatable {
         public let id: Int
-        public let categoryName: String
-        public let categoryId: Int?
+        public let categoryId: Int
         public let title: String
         public let data: String
         public let memo: String
@@ -38,8 +38,7 @@ public extension ContentDetail {
         
         public init(
             id: Int,
-            categoryName: String,
-            categoryId: Int?,
+            categoryId: Int,
             title: String,
             data: String,
             memo: String,
@@ -48,7 +47,6 @@ public extension ContentDetail {
             alertYn: RemindState
         ) {
             self.id = id
-            self.categoryName = categoryName
             self.categoryId = categoryId
             self.title = title
             self.data = data

--- a/Projects/Domain/Sources/ContentDetail/ContentDetail.swift
+++ b/Projects/Domain/Sources/ContentDetail/ContentDetail.swift
@@ -10,57 +10,17 @@ import Foundation
 public struct ContentDetail: Equatable {
     // - MARK: Response
     /// 콘텐츠(링크) 상세
-    public var content: ContentDetail.Content?
+    public var content: BaseContentDetail?
     public var category: BaseCategoryDetail?
     // - MARK: Request
     /// 조회할 콘텐츠 id
     public let contentId: Int
     
     public init(
-        content: ContentDetail.Content? = nil,
+        content: BaseContentDetail? = nil,
         contentId: Int
     ) {
         self.content = content
         self.contentId = contentId
-    }
-}
-
-public extension ContentDetail {
-    struct Content: Equatable {
-        public let id: Int
-        public let categoryId: Int
-        public let title: String
-        public let data: String
-        public let memo: String
-        public let createdAt: Date
-        public var favorites: Bool
-        public var alertYn: RemindState
-        
-        public init(
-            id: Int,
-            categoryId: Int,
-            title: String,
-            data: String,
-            memo: String,
-            createdAt: Date,
-            favorites: Bool,
-            alertYn: RemindState
-        ) {
-            self.id = id
-            self.categoryId = categoryId
-            self.title = title
-            self.data = data
-            self.memo = memo
-            self.createdAt = createdAt
-            self.favorites = favorites
-            self.alertYn = alertYn
-        }
-    }
-}
-
-public extension ContentDetail.Content {
-    enum RemindState: String, Equatable {
-        case yes = "YES"
-        case no = "NO"
     }
 }

--- a/Projects/Domain/Sources/ContentList/ContentList.swift
+++ b/Projects/Domain/Sources/ContentList/ContentList.swift
@@ -11,6 +11,7 @@ public struct ContentList: Equatable {
     // - MARK: Response
     /// 콘텐츠 목록
     public var contentList: BaseContentListInquiry
+    public var pageable: BasePageable
     
     public init() {
         self.contentList = .init(
@@ -19,6 +20,10 @@ public struct ContentList: Equatable {
             size: 0,
             sort: [],
             hasNext: false
+        )
+        self.pageable = .init(
+            page: 0, size: 10,
+            sort: ["desc"]
         )
     }
 }

--- a/Projects/Domain/Sources/ContentSetting/ContentSetting.swift
+++ b/Projects/Domain/Sources/ContentSetting/ContentSetting.swift
@@ -10,7 +10,7 @@ import Foundation
 public struct ContentSetting: Equatable {
     // - MARK: Response
     /// 조회할 콘텐츠(링크)
-    public var content: BaseContent?
+    public var content: ContentDetail.Content?
     /// 카테고리(포킷) 리스트
     public var categoryListInQuiry: BaseCategoryListInquiry
     /// 유저가 등록한 카테고리(포킷) 개수
@@ -25,11 +25,11 @@ public struct ContentSetting: Equatable {
     /// 등록 또는 수정할 콘텐츠(링크) 메모
     public var memo: String
     /// 등록 또는 수정할 콘텐츠(링크) 리마인드 여부
-    public var alertYn: BaseContent.RemindState
+    public var alertYn: ContentDetail.Content.RemindState
     /// 카테고리 리스트의 조회할 페이징 정보
     public var pageable: BasePageable
     
-    public init(content: BaseContent?, data: String?) {
+    public init(content: ContentDetail.Content?, data: String?) {
         self.content = content
         
         let categoryListInquiry = BaseCategoryListInquiry(

--- a/Projects/Domain/Sources/ContentSetting/ContentSetting.swift
+++ b/Projects/Domain/Sources/ContentSetting/ContentSetting.swift
@@ -16,6 +16,8 @@ public struct ContentSetting: Equatable {
     /// 유저가 등록한 카테고리(포킷) 개수
     public var categoryTotalCount: Int
     // - MARK: Request
+    /// 수정할 콘텐츠(링크) id
+    public var contentId: Int?
     /// 등록 또는 수정할 콘텐츠(링크) url
     public var data: String
     /// 등록 또는 수정할 콘텐츠(링크) 제목
@@ -29,8 +31,8 @@ public struct ContentSetting: Equatable {
     /// 카테고리 리스트의 조회할 페이징 정보
     public var pageable: BasePageable
     
-    public init(content: ContentDetail.Content?, data: String?) {
-        self.content = content
+    public init(contentId: Int?, data: String?) {
+        self.contentId = contentId
         
         let categoryListInquiry = BaseCategoryListInquiry(
             data: [],
@@ -49,8 +51,8 @@ public struct ContentSetting: Equatable {
         self.alertYn = content?.alertYn ?? .no
         self.pageable = .init(
             page: 0,
-            size: 0,
-            sort: []
+            size: 10,
+            sort: ["desc"]
         )
     }
 }

--- a/Projects/Domain/Sources/ContentSetting/ContentSetting.swift
+++ b/Projects/Domain/Sources/ContentSetting/ContentSetting.swift
@@ -10,7 +10,7 @@ import Foundation
 public struct ContentSetting: Equatable {
     // - MARK: Response
     /// 조회할 콘텐츠(링크)
-    public var content: ContentDetail.Content?
+    public var content: BaseContentDetail?
     /// 카테고리(포킷) 리스트
     public var categoryListInQuiry: BaseCategoryListInquiry
     /// 유저가 등록한 카테고리(포킷) 개수
@@ -27,7 +27,7 @@ public struct ContentSetting: Equatable {
     /// 등록 또는 수정할 콘텐츠(링크) 메모
     public var memo: String
     /// 등록 또는 수정할 콘텐츠(링크) 리마인드 여부
-    public var alertYn: ContentDetail.Content.RemindState
+    public var alertYn: BaseContentDetail.RemindState
     /// 카테고리 리스트의 조회할 페이징 정보
     public var pageable: BasePageable
     

--- a/Projects/Domain/Sources/DTO/Base/BaseContentResponse+Extension.swift
+++ b/Projects/Domain/Sources/DTO/Base/BaseContentResponse+Extension.swift
@@ -11,7 +11,7 @@ import CoreKit
 import Util
 
 public extension ContentBaseResponse {
-    func toDomain() -> BaseContent {
+    func toDomain() -> BaseContentItem {
         return .init(
             id: self.contentId,
             categoryName: self.category.categoryName,

--- a/Projects/Domain/Sources/DTO/Base/BaseContentResponse+Extension.swift
+++ b/Projects/Domain/Sources/DTO/Base/BaseContentResponse+Extension.swift
@@ -20,7 +20,7 @@ public extension ContentBaseResponse {
             thumbNail: self.thumbNail,
             data: self.data,
             domain: self.domain,
-            createdAt: DateFormatter.stringToDate(string: self.createdAt),
+            createdAt: self.createdAt,
             isRead: self.isRead
         )
     }

--- a/Projects/Domain/Sources/DTO/Base/BaseContentResponse+Extension.swift
+++ b/Projects/Domain/Sources/DTO/Base/BaseContentResponse+Extension.swift
@@ -14,16 +14,14 @@ public extension ContentBaseResponse {
     func toDomain() -> BaseContent {
         return .init(
             id: self.contentId,
-            categoryName: self.categoryName,
-            categoryId: self.categoryId,
+            categoryName: self.category.categoryName,
+            categoryId: self.category.categoryId,
             title: self.title,
             thumbNail: self.thumbNail,
             data: self.data,
             domain: self.domain,
-            memo: self.memo,
             createdAt: DateFormatter.stringToDate(string: self.createdAt),
-            isRead: self.isRead,
-            favorites: self.favorites,
-            alertYn: BaseContent.RemindState(rawValue: self.alertYn) ?? .no)
+            isRead: self.isRead
+        )
     }
 }

--- a/Projects/Domain/Sources/DTO/Category/CategoryEditResponse+Extension.swift
+++ b/Projects/Domain/Sources/DTO/Category/CategoryEditResponse+Extension.swift
@@ -10,7 +10,7 @@ import Foundation
 import CoreKit
 
 public extension CategoryEditResponse {
-    func toDomain() -> BaseCategoryDetail {
+    func toDomain() -> BaseCategory {
         return .init(
             categoryId: self.categoryId,
             categoryName: self.categoryName,

--- a/Projects/Domain/Sources/DTO/Category/CategoryEditResponse+Extension.swift
+++ b/Projects/Domain/Sources/DTO/Category/CategoryEditResponse+Extension.swift
@@ -9,6 +9,16 @@ import Foundation
 
 import CoreKit
 
+public extension CategoryEditResponse {
+    func toDomain() -> BaseCategoryDetail {
+        return .init(
+            categoryId: self.categoryId,
+            categoryName: self.categoryName,
+            categoryImage: self.categoryImage.toDomain()
+        )
+    }
+}
+
 public extension CategoryImageResponse {
     func toDomain() -> BaseCategoryImage {
         return .init(imageId: self.imageId, imageURL: self.imageUrl)

--- a/Projects/Domain/Sources/DTO/Category/CategoryListInquiryResponse+Extention.swift
+++ b/Projects/Domain/Sources/DTO/Category/CategoryListInquiryResponse+Extention.swift
@@ -22,7 +22,7 @@ public extension CategoryListInquiryResponse {
 }
 
 public extension CategoryItemInquiryResponse {
-    func toDomain() -> BaseCategory {
+    func toDomain() -> BaseCategoryItem {
         return .init(
             id: self.categoryId,
             userId: self.userId,

--- a/Projects/Domain/Sources/DTO/Content/ContentDetailResponse+Extension.swift
+++ b/Projects/Domain/Sources/DTO/Content/ContentDetailResponse+Extension.swift
@@ -21,6 +21,6 @@ public extension ContentDetailResponse {
             memo: self.memo,
             createdAt: DateFormatter.stringToDate(string: self.createdAt),
             favorites: self.favorites,
-            alertYn: BaseContent.RemindState(rawValue: self.alertYn) ?? .no)
+            alertYn: ContentDetail.Content.RemindState(rawValue: self.alertYn) ?? .no)
     }
 }

--- a/Projects/Domain/Sources/DTO/Content/ContentDetailResponse+Extension.swift
+++ b/Projects/Domain/Sources/DTO/Content/ContentDetailResponse+Extension.swift
@@ -14,7 +14,6 @@ public extension ContentDetailResponse {
     func toDomain() -> ContentDetail.Content {
         return .init(
             id: self.contentId,
-            categoryName: self.categoryName,
             categoryId: self.categoryId,
             title: self.title,
             data: self.data,

--- a/Projects/Domain/Sources/DTO/Content/ContentDetailResponse+Extension.swift
+++ b/Projects/Domain/Sources/DTO/Content/ContentDetailResponse+Extension.swift
@@ -11,7 +11,7 @@ import CoreKit
 import Util
 
 public extension ContentDetailResponse {
-    func toDomain() -> ContentDetail.Content {
+    func toDomain() -> BaseContentDetail {
         return .init(
             id: self.contentId,
             categoryId: self.categoryId,
@@ -20,6 +20,6 @@ public extension ContentDetailResponse {
             memo: self.memo,
             createdAt: DateFormatter.stringToDate(string: self.createdAt),
             favorites: self.favorites,
-            alertYn: ContentDetail.Content.RemindState(rawValue: self.alertYn) ?? .no)
+            alertYn: BaseContentDetail.RemindState(rawValue: self.alertYn) ?? .no)
     }
 }

--- a/Projects/Domain/Sources/DTO/Content/ContentDetailResponse+Extension.swift
+++ b/Projects/Domain/Sources/DTO/Content/ContentDetailResponse+Extension.swift
@@ -17,7 +17,6 @@ public extension ContentDetailResponse {
             categoryName: self.categoryName,
             categoryId: self.categoryId,
             title: self.title,
-            thumbNail: self.thumbNail,
             data: self.data,
             memo: self.memo,
             createdAt: DateFormatter.stringToDate(string: self.createdAt),

--- a/Projects/Domain/Sources/Remind/Remind.swift
+++ b/Projects/Domain/Sources/Remind/Remind.swift
@@ -12,20 +12,16 @@ import Util
 public struct Remind: Equatable {
     // - MARK: Response
     /// 오늘의 추천 콘텐츠(링크) 리스트
-    public var recommendedList: BaseContentListInquiry
+    public var recommendedList: [BaseContent]
     /// 읽지 않은 콘텐츠(링크) 리스트
     public var unreadList: BaseContentListInquiry
+    public var unreadListPageable: BasePageable
     /// 즐겨찾기한 콘텐츠(링크) 리스트
     public var favoriteList: BaseContentListInquiry
+    public var favoriteListPageable: BasePageable
     
     public init() {
-        self.recommendedList = .init(
-            data: [],
-            page: 0,
-            size: 3,
-            sort: [],
-            hasNext: false
-        )
+        self.recommendedList = []
         self.unreadList = .init(
             data: [],
             page: 0,
@@ -33,12 +29,22 @@ public struct Remind: Equatable {
             sort: [],
             hasNext: false
         )
+        self.unreadListPageable = .init(
+            page: 0,
+            size: 3,
+            sort: []
+        )
         self.favoriteList = .init(
             data: [],
             page: 0,
             size: 3,
             sort: [],
             hasNext: false
+        )
+        self.favoriteListPageable = .init(
+            page: 0,
+            size: 3,
+            sort: []
         )
     }
 }

--- a/Projects/Domain/Sources/Remind/Remind.swift
+++ b/Projects/Domain/Sources/Remind/Remind.swift
@@ -32,7 +32,7 @@ public struct Remind: Equatable {
         self.unreadListPageable = .init(
             page: 0,
             size: 3,
-            sort: []
+            sort: ["desc"]
         )
         self.favoriteList = .init(
             data: [],
@@ -44,7 +44,7 @@ public struct Remind: Equatable {
         self.favoriteListPageable = .init(
             page: 0,
             size: 3,
-            sort: []
+            sort: ["desc"]
         )
     }
 }

--- a/Projects/Domain/Sources/Remind/Remind.swift
+++ b/Projects/Domain/Sources/Remind/Remind.swift
@@ -12,7 +12,7 @@ import Util
 public struct Remind: Equatable {
     // - MARK: Response
     /// 오늘의 추천 콘텐츠(링크) 리스트
-    public var recommendedList: [BaseContent]
+    public var recommendedList: [BaseContentItem]
     /// 읽지 않은 콘텐츠(링크) 리스트
     public var unreadList: BaseContentListInquiry
     public var unreadListPageable: BasePageable

--- a/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailFeature.swift
+++ b/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailFeature.swift
@@ -25,7 +25,7 @@ public struct CategoryDetailFeature {
     public struct State: Equatable {
         /// Domain
         fileprivate var domain: CategoryDetail
-        var category: BaseCategory {
+        var category: BaseCategoryItem {
             get { domain.category }
         }
         var isUnreadFiltered: Bool {
@@ -38,8 +38,8 @@ public struct CategoryDetailFeature {
         var sortType: SortType {
             get { domain.pageable.sort == ["DESC"] ? .최신순 : .오래된순 }
         }
-        var categories: IdentifiedArrayOf<BaseCategory> {
-            var identifiedArray = IdentifiedArrayOf<BaseCategory>()
+        var categories: IdentifiedArrayOf<BaseCategoryItem> {
+            var identifiedArray = IdentifiedArrayOf<BaseCategoryItem>()
             domain.categoryListInQuiry.data.forEach { category in
                 identifiedArray.append(category)
             }
@@ -60,7 +60,7 @@ public struct CategoryDetailFeature {
         var isPokitDeleteSheetPresented: Bool = false
         var isFilterSheetPresented: Bool = false
         
-        public init(category: BaseCategory) {
+        public init(category: BaseCategoryItem) {
             self.domain = .init(categpry: category)
         }
     }
@@ -80,7 +80,7 @@ public struct CategoryDetailFeature {
             /// - Button Tapped
             case categoryKebobButtonTapped(PokitDeleteBottomSheet.SheetType, selectedItem: BaseContentItem?)
             case categorySelectButtonTapped
-            case categorySelected(BaseCategory)
+            case categorySelected(BaseCategoryItem)
             case filterButtonTapped
             case contentItemTapped(BaseContentItem)
             case dismiss
@@ -112,7 +112,7 @@ public struct CategoryDetailFeature {
             case linkCopyDetected(URL?)
             case 링크수정(contentId: Int)
             case 포킷삭제
-            case 포킷수정(BaseCategory)
+            case 포킷수정(BaseCategoryItem)
             case 포킷공유
         }
     }

--- a/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailFeature.swift
+++ b/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailFeature.swift
@@ -45,15 +45,15 @@ public struct CategoryDetailFeature {
             }
             return identifiedArray
         }
-        var contents: IdentifiedArrayOf<BaseContent> {
-            var identifiedArray = IdentifiedArrayOf<BaseContent>()
+        var contents: IdentifiedArrayOf<BaseContentItem> {
+            var identifiedArray = IdentifiedArrayOf<BaseContentItem>()
             domain.contentList.data.forEach { content in
                 identifiedArray.append(content)
             }
             return identifiedArray
         }
         var kebobSelectedType: PokitDeleteBottomSheet.SheetType?
-        var selectedContentItem: BaseContent?
+        var selectedContentItem: BaseContentItem?
         /// sheet Presented
         var isCategorySheetPresented: Bool = false
         var isCategorySelectSheetPresented: Bool = false
@@ -78,11 +78,11 @@ public struct CategoryDetailFeature {
             /// - Binding
             case binding(BindingAction<State>)
             /// - Button Tapped
-            case categoryKebobButtonTapped(PokitDeleteBottomSheet.SheetType, selectedItem: BaseContent?)
+            case categoryKebobButtonTapped(PokitDeleteBottomSheet.SheetType, selectedItem: BaseContentItem?)
             case categorySelectButtonTapped
             case categorySelected(BaseCategory)
             case filterButtonTapped
-            case contentItemTapped(BaseContent)
+            case contentItemTapped(BaseContentItem)
             case dismiss
             case onAppear
         }
@@ -108,7 +108,7 @@ public struct CategoryDetailFeature {
         }
         
         public enum DelegateAction: Equatable {
-            case contentItemTapped(BaseContent)
+            case contentItemTapped(BaseContentItem)
             case linkCopyDetected(URL?)
             case 링크수정(contentId: Int)
             case 포킷삭제

--- a/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailFeature.swift
+++ b/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailFeature.swift
@@ -15,9 +15,12 @@ import Util
 @Reducer
 public struct CategoryDetailFeature {
     /// - Dependency
-    @Dependency(\.dismiss) var dismiss
-    @Dependency(\.pasteboard) var pasteboard
-    @Dependency(\.categoryClient) var categoryClient
+    @Dependency(\.dismiss)
+    private var dismiss
+    @Dependency(\.pasteboard)
+    private var pasteboard
+    @Dependency(\.categoryClient)
+    private var categoryClient
     @Dependency(\.contentClient)
     private var contentClient
     /// - State
@@ -110,7 +113,7 @@ public struct CategoryDetailFeature {
         public enum DelegateAction: Equatable {
             case contentItemTapped(BaseContentItem)
             case linkCopyDetected(URL?)
-            case 링크수정(id: Int)
+            case 링크수정(contentId: Int)
             case 포킷삭제
             case 포킷수정(BaseCategoryItem)
             case 포킷공유
@@ -285,7 +288,7 @@ private extension CategoryDetailFeature {
                     case .링크삭제:
                         guard let content else { return }
                         await send(.inner(.pokitCategorySheetPresented(false)))
-                        await send(.delegate(.링크수정(id: content.id)))
+                        await send(.delegate(.링크수정(contentId: content.id)))
                     case .포킷삭제:
                         await send(.inner(.pokitCategorySheetPresented(false)))
                         await send(.delegate(.포킷수정(category)))

--- a/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailFeature.swift
+++ b/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailFeature.swift
@@ -169,8 +169,10 @@ private extension CategoryDetailFeature {
             
         case .categorySelected(let item):
             state.domain.category = item
-            //TODO: 현재 아이템 값을 통해 카테고리 내 컨텐츠 리스트들을 뿌려줘야 함
-            return .send(.inner(.pokitCategorySelectSheetPresented(false)))
+            return .run { send in
+                await send(.async(.카테고리_내_컨텐츠_목록_조회))
+                await send(.inner(.pokitCategorySelectSheetPresented(false)))
+            }
             
         case .filterButtonTapped:
             state.isFilterSheetPresented.toggle()

--- a/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailFeature.swift
+++ b/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailFeature.swift
@@ -36,7 +36,7 @@ public struct CategoryDetailFeature {
         }
         // - TODO: 더 구체적인 처리 필요
         var sortType: SortType {
-            get { domain.pageable.sort == ["DESC"] ? .최신순 : .오래된순 }
+            get { domain.pageable.sort == ["desc"] ? .최신순 : .오래된순 }
         }
         var categories: IdentifiedArrayOf<BaseCategoryItem> {
             var identifiedArray = IdentifiedArrayOf<BaseCategoryItem>()
@@ -341,7 +341,7 @@ private extension CategoryDetailFeature {
                 state.isFilterSheetPresented.toggle()
                 state.domain.pageable.sort = [
                     "createdAt",
-                    type == .최신순 ? "DESC" : "ASC"
+                    type == .최신순 ? "desc" : "asc"
                 ]
                 state.domain.condition.isFavoriteFlitered = bookMarkSelected
                 state.domain.condition.isUnreadFlitered = unReadSelected

--- a/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailFeature.swift
+++ b/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailFeature.swift
@@ -93,12 +93,12 @@ public struct CategoryDetailFeature {
             case pokitDeleteSheetPresented(Bool)
             case 카테고리_목록_조회_결과(BaseCategoryListInquiry)
             case 카테고리_내_컨텐츠_목록_갱신(BaseContentListInquiry)
-            case 컨텐츠_삭제_반영(contentId: Int)
+            case 컨텐츠_삭제_반영(id: Int)
         }
         
         public enum AsyncAction: Equatable {
             case 카테고리_내_컨텐츠_목록_조회
-            case 컨텐츠_삭제(contentId: Int)
+            case 컨텐츠_삭제(id: Int)
         }
         
         public enum ScopeAction: Equatable {
@@ -110,7 +110,7 @@ public struct CategoryDetailFeature {
         public enum DelegateAction: Equatable {
             case contentItemTapped(BaseContentItem)
             case linkCopyDetected(URL?)
-            case 링크수정(contentId: Int)
+            case 링크수정(id: Int)
             case 포킷삭제
             case 포킷수정(BaseCategoryItem)
             case 포킷공유
@@ -224,7 +224,7 @@ private extension CategoryDetailFeature {
         case .카테고리_내_컨텐츠_목록_갱신(let contentList):
             state.domain.contentList = contentList
             return .none
-        case .컨텐츠_삭제_반영(contentId: let id):
+        case .컨텐츠_삭제_반영(id: let id):
             state.domain.contentList.data.removeAll { $0.id == id }
             state.selectedContentItem = nil
             state.isPokitDeleteSheetPresented = false
@@ -257,10 +257,10 @@ private extension CategoryDetailFeature {
                 ).toDomain()
                 await send(.inner(.카테고리_내_컨텐츠_목록_갱신(contentList)))
             }
-        case .컨텐츠_삭제(contentId: let id):
+        case .컨텐츠_삭제(id: let id):
             return .run { [id] send in
                 let _ = try await contentClient.컨텐츠_삭제("\(id)")
-                await send(.inner(.컨텐츠_삭제_반영(contentId: id)), animation: .pokitSpring)
+                await send(.inner(.컨텐츠_삭제_반영(id: id)), animation: .pokitSpring)
             }
         }
     }
@@ -285,7 +285,7 @@ private extension CategoryDetailFeature {
                     case .링크삭제:
                         guard let content else { return }
                         await send(.inner(.pokitCategorySheetPresented(false)))
-                        await send(.delegate(.링크수정(contentId: content.id)))
+                        await send(.delegate(.링크수정(id: content.id)))
                     case .포킷삭제:
                         await send(.inner(.pokitCategorySheetPresented(false)))
                         await send(.delegate(.포킷수정(category)))
@@ -319,7 +319,7 @@ private extension CategoryDetailFeature {
                         state.isPokitDeleteSheetPresented = false
                         return .none
                     }
-                    return .send(.async(.컨텐츠_삭제(contentId: selectedItem.id)))
+                    return .send(.async(.컨텐츠_삭제(id: selectedItem.id)))
                     
                 case .포킷삭제:
                     state.isPokitDeleteSheetPresented = false

--- a/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailFeature.swift
+++ b/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailFeature.swift
@@ -93,7 +93,7 @@ public struct CategoryDetailFeature {
         public enum DelegateAction: Equatable {
             case contentItemTapped(BaseContent)
             case linkCopyDetected(URL?)
-            case 링크수정(BaseContent)
+            case 링크수정(contentId: Int)
             case 포킷삭제
             case 포킷수정(BaseCategory)
             case 포킷공유
@@ -223,16 +223,16 @@ private extension CategoryDetailFeature {
                 
             case .editCellButtonTapped:
                 return .run { [
-                    link = state.selectedContentItem,
+                    content = state.selectedContentItem,
                     type = state.kebobSelectedType,
                     category = state.category
                 ] send in
                     guard let type else { return }
                     switch type {
                     case .링크삭제:
-                        guard let link else { return }
+                        guard let content else { return }
                         await send(.inner(.pokitCategorySheetPresented(false)))
-                        await send(.delegate(.링크수정(link)))
+                        await send(.delegate(.링크수정(contentId: content.id)))
                     case .포킷삭제:
                         await send(.inner(.pokitCategorySheetPresented(false)))
                         await send(.delegate(.포킷수정(category)))

--- a/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailView.swift
+++ b/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailView.swift
@@ -58,6 +58,9 @@ public extension CategoryDetailView {
             }
             .sheet(isPresented: $store.isFilterSheetPresented) {
                 CategoryFilterSheet(
+                    sortType: store.sortType,
+                    isBookMarkSelected: store.isFavoriteFiltered,
+                    isUnreadSeleected: store.isUnreadFiltered,
                     delegateSend: { store.send(.scope(.filterBottomSheet($0))) }
                 )
             }

--- a/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailView.swift
+++ b/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailView.swift
@@ -134,14 +134,14 @@ private extension CategoryDetailView {
     
     struct PokitCategorySheet: View {
         @State private var height: CGFloat = 0
-        var action: (BaseCategory) -> Void
-        var selectedItem: BaseCategory?
-        var list: [BaseCategory]
+        var action: (BaseCategoryItem) -> Void
+        var selectedItem: BaseCategoryItem?
+        var list: [BaseCategoryItem]
         
         public init(
-            selectedItem: BaseCategory?,
-            list: [BaseCategory],
-            action: @escaping (BaseCategory) -> Void
+            selectedItem: BaseCategoryItem?,
+            list: [BaseCategoryItem],
+            action: @escaping (BaseCategoryItem) -> Void
         ) {
             self.selectedItem = selectedItem
             self.list = list

--- a/Projects/Feature/FeatureCategoryDetail/Sources/Sheet/CategoryFilterSheet.swift
+++ b/Projects/Feature/FeatureCategoryDetail/Sources/Sheet/CategoryFilterSheet.swift
@@ -11,14 +11,20 @@ import DSKit
 public struct CategoryFilterSheet: View {
     
     @State private var height: CGFloat = 0
-    @State private var sortType: SortType = .최신순
-    @State private var isBookMarkSelected: Bool = true
-    @State private var isUnReadSelected: Bool = true
+    @State private var sortType: SortType
+    @State private var isBookMarkSelected: Bool
+    @State private var isUnReadSelected: Bool
     private let delegateSend: ((CategoryFilterSheet.Delegate) -> Void)?
     
     public init(
+        sortType: SortType,
+        isBookMarkSelected: Bool,
+        isUnreadSeleected: Bool,
         delegateSend: ((CategoryFilterSheet.Delegate) -> Void)?
     ) {
+        self._sortType = .init(initialValue: sortType)
+        self._isBookMarkSelected = .init(initialValue: isBookMarkSelected)
+        self._isUnReadSelected = .init(initialValue: isUnreadSeleected)
         self.delegateSend = delegateSend
     }
     
@@ -174,7 +180,12 @@ public extension CategoryFilterSheet {
 }
 //MARK: - Preview
 #Preview {
-    CategoryFilterSheet(delegateSend: nil)
+    CategoryFilterSheet(
+        sortType: .최신순,
+        isBookMarkSelected: true,
+        isUnreadSeleected: true,
+        delegateSend: nil
+    )
 }
 
 

--- a/Projects/Feature/FeatureCategorySetting/Sources/PokitCategorySettingFeature.swift
+++ b/Projects/Feature/FeatureCategorySetting/Sources/PokitCategorySettingFeature.swift
@@ -36,8 +36,8 @@ public struct PokitCategorySettingFeature {
         var profileImages: [BaseCategoryImage] {
             get { domain.imageList }
         }
-        var itemList: IdentifiedArrayOf<BaseCategory> {
-            var identifiedArray = IdentifiedArrayOf<BaseCategory>()
+        var itemList: IdentifiedArrayOf<BaseCategoryItem> {
+            var identifiedArray = IdentifiedArrayOf<BaseCategoryItem>()
             domain.categoryListInQuiry.data.forEach { category in
                 identifiedArray.append(category)
             }

--- a/Projects/Feature/FeatureCategorySetting/Sources/PokitCategorySettingView.swift
+++ b/Projects/Feature/FeatureCategorySetting/Sources/PokitCategorySettingView.swift
@@ -152,9 +152,9 @@ private extension PokitCategorySettingView {
     }
     /// 내포킷 Item
     struct PokitItem: View {
-        let item: BaseCategory
+        let item: BaseCategoryItem
         
-        init(item: BaseCategory) {
+        init(item: BaseCategoryItem) {
             self.item = item
         }
         

--- a/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailFeature.swift
+++ b/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailFeature.swift
@@ -32,7 +32,7 @@ public struct ContentDetailFeature {
         var content: BaseContentDetail? {
             get { domain.content }
         }
-        var category: BaseCategoryDetail? {
+        var category: BaseCategory? {
             get { domain.category }
         }
         var linkTitle: String? = nil
@@ -69,7 +69,7 @@ public struct ContentDetailFeature {
             case dismissAlert
             case 컨텐츠_상세_조회(content: BaseContentDetail)
             case 즐겨찾기_갱신(Bool)
-            case 카테고리_갱신(BaseCategoryDetail)
+            case 카테고리_갱신(BaseCategory)
         }
         
         public enum AsyncAction: Equatable {

--- a/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailFeature.swift
+++ b/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailFeature.swift
@@ -72,7 +72,7 @@ public struct ContentDetailFeature {
         public enum ScopeAction: Equatable { case doNothing }
         
         public enum DelegateAction: Equatable {
-            case editButtonTapped(content: BaseContent)
+            case editButtonTapped(content: ContentDetail.Content)
         }
     }
     
@@ -122,25 +122,9 @@ private extension ContentDetailFeature {
             return .none
         case .editButtonTapped:
             guard let content = state.domain.content else { return .none }
-            let base = BaseContent(
-                id: content.id,
-                categoryName: content.categoryName,
-                categoryId: content.categoryId,
-                title: content.title,
-                // - MARK: 콘텐츠 통일 필요..?
-                thumbNail: "",
-                data: content.data,
-                // - MARK: 콘텐츠 통일 필요..?
-                domain: "youtube",
-                memo: content.memo,
-                createdAt: content.createdAt,
-                isRead: true,
-                favorites: content.favorites,
-                alertYn: content.alertYn
-            )
-            return .run { [base] send in
+            return .run { [content] send in
 //                await dismiss()
-                await send(.delegate(.editButtonTapped(content: base)))
+                await send(.delegate(.editButtonTapped(content: content)))
             }
         case .deleteButtonTapped:
             state.showAlert = true

--- a/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailFeature.swift
+++ b/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailFeature.swift
@@ -82,7 +82,7 @@ public struct ContentDetailFeature {
         public enum ScopeAction: Equatable { case doNothing }
         
         public enum DelegateAction: Equatable {
-            case editButtonTapped(content: ContentDetail.Content)
+            case editButtonTapped(contentId: Int)
         }
     }
     
@@ -134,7 +134,7 @@ private extension ContentDetailFeature {
             guard let content = state.domain.content else { return .none }
             return .run { [content] send in
 //                await dismiss()
-                await send(.delegate(.editButtonTapped(content: content)))
+                await send(.delegate(.editButtonTapped(contentId: content.id)))
             }
         case .deleteButtonTapped:
             state.showAlert = true

--- a/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailFeature.swift
+++ b/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailFeature.swift
@@ -83,8 +83,8 @@ public struct ContentDetailFeature {
         public enum ScopeAction: Equatable { case doNothing }
         
         public enum DelegateAction: Equatable {
-            case editButtonTapped(id: Int)
-            case 컨텐츠_삭제_완료(id: Int)
+            case editButtonTapped(contentId: Int)
+            case 컨텐츠_삭제_완료(contentId: Int)
         }
     }
     
@@ -135,7 +135,7 @@ private extension ContentDetailFeature {
         case .editButtonTapped:
             guard let content = state.domain.content else { return .none }
             return .run { [content] send in
-                await send(.delegate(.editButtonTapped(id: content.id)))
+                await send(.delegate(.editButtonTapped(contentId: content.id)))
             }
         case .deleteButtonTapped:
             state.showAlert = true
@@ -231,7 +231,7 @@ private extension ContentDetailFeature {
         case .컨텐츠_삭제(id: let id):
             return .run { [id] send in
                 let _ = try await contentClient.컨텐츠_삭제("\(id)")
-                await send(.delegate(.컨텐츠_삭제_완료(id: id)))
+                await send(.delegate(.컨텐츠_삭제_완료(contentId: id)))
             }
         }
     }

--- a/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailFeature.swift
+++ b/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailFeature.swift
@@ -77,12 +77,14 @@ public struct ContentDetailFeature {
             case 즐겨찾기(id: Int)
             case 즐겨찾기_취소(id: Int)
             case 카테고리_상세_조회(id: Int)
+            case 컨텐츠_삭제(contentId: Int)
         }
         
         public enum ScopeAction: Equatable { case doNothing }
         
         public enum DelegateAction: Equatable {
             case editButtonTapped(contentId: Int)
+            case 컨텐츠_삭제_완료(contentId: Int)
         }
     }
     
@@ -140,10 +142,10 @@ private extension ContentDetailFeature {
             state.showAlert = true
             return .none
         case .deleteAlertConfirmTapped:
-            return .run { send in
+            return .run { [id = state.domain.contentId] send in
                 //TODO: 링크 삭제
                 await send(.inner(.dismissAlert))
-                await dismiss()
+                await send(.async(.컨텐츠_삭제(contentId: id)))
             }
         case .binding:
             return .none
@@ -226,6 +228,11 @@ private extension ContentDetailFeature {
             return .run { [id] send in
                 let category = try await categoryClient.카테고리_상세_조회("\(id)").toDomain()
                 await send(.inner(.카테고리_갱신(category)))
+            }
+        case .컨텐츠_삭제(contentId: let id):
+            return .run { [id] send in
+                let _ = try await contentClient.컨텐츠_삭제("\(id)")
+                await send(.delegate(.컨텐츠_삭제_완료(contentId: id)))
             }
         }
     }

--- a/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailFeature.swift
+++ b/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailFeature.swift
@@ -148,9 +148,15 @@ private extension ContentDetailFeature {
         case .binding:
             return .none
         case .favoriteButtonTapped:
-            state.domain.content?.favorites.toggle()
-            return .run { send in
-                
+            guard let content = state.domain.content else {
+                return .none
+            }
+            return .run { [content] send in
+                if content.favorites {
+                    await send(.async(.즐겨찾기_취소(id: content.id)))
+                } else {
+                    await send(.async(.즐겨찾기(id: content.id)))
+                }
             }
         }
     }

--- a/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailFeature.swift
+++ b/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailFeature.swift
@@ -77,14 +77,14 @@ public struct ContentDetailFeature {
             case 즐겨찾기(id: Int)
             case 즐겨찾기_취소(id: Int)
             case 카테고리_상세_조회(id: Int)
-            case 컨텐츠_삭제(contentId: Int)
+            case 컨텐츠_삭제(id: Int)
         }
         
         public enum ScopeAction: Equatable { case doNothing }
         
         public enum DelegateAction: Equatable {
-            case editButtonTapped(contentId: Int)
-            case 컨텐츠_삭제_완료(contentId: Int)
+            case editButtonTapped(id: Int)
+            case 컨텐츠_삭제_완료(id: Int)
         }
     }
     
@@ -135,8 +135,7 @@ private extension ContentDetailFeature {
         case .editButtonTapped:
             guard let content = state.domain.content else { return .none }
             return .run { [content] send in
-//                await dismiss()
-                await send(.delegate(.editButtonTapped(contentId: content.id)))
+                await send(.delegate(.editButtonTapped(id: content.id)))
             }
         case .deleteButtonTapped:
             state.showAlert = true
@@ -145,7 +144,7 @@ private extension ContentDetailFeature {
             return .run { [id = state.domain.contentId] send in
                 //TODO: 링크 삭제
                 await send(.inner(.dismissAlert))
-                await send(.async(.컨텐츠_삭제(contentId: id)))
+                await send(.async(.컨텐츠_삭제(id: id)))
             }
         case .binding:
             return .none
@@ -229,10 +228,10 @@ private extension ContentDetailFeature {
                 let category = try await categoryClient.카테고리_상세_조회("\(id)").toDomain()
                 await send(.inner(.카테고리_갱신(category)))
             }
-        case .컨텐츠_삭제(contentId: let id):
+        case .컨텐츠_삭제(id: let id):
             return .run { [id] send in
                 let _ = try await contentClient.컨텐츠_삭제("\(id)")
-                await send(.delegate(.컨텐츠_삭제_완료(contentId: id)))
+                await send(.delegate(.컨텐츠_삭제_완료(id: id)))
             }
         }
     }

--- a/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailFeature.swift
+++ b/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailFeature.swift
@@ -29,7 +29,7 @@ public struct ContentDetailFeature {
             self.domain = .init(contentId: contentId)
         }
         fileprivate var domain: ContentDetail
-        var content: ContentDetail.Content? {
+        var content: BaseContentDetail? {
             get { domain.content }
         }
         var category: BaseCategoryDetail? {
@@ -67,7 +67,7 @@ public struct ContentDetailFeature {
             case parsingInfo(title: String?, image: UIImage?)
             case parsingURL
             case dismissAlert
-            case 컨텐츠_상세_조회(content: ContentDetail.Content)
+            case 컨텐츠_상세_조회(content: BaseContentDetail)
             case 즐겨찾기_갱신(Bool)
             case 카테고리_갱신(BaseCategoryDetail)
         }

--- a/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailView.swift
+++ b/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailView.swift
@@ -76,7 +76,7 @@ public extension ContentDetailView {
 //MARK: - Configure View
 private extension ContentDetailView {
     @ViewBuilder
-    func remindAndBadge(content: ContentDetail.Content) -> some View {
+    func remindAndBadge(content: BaseContentDetail) -> some View {
         HStack(spacing: 4) {
             if content.alertYn == .yes {
                 Image(.icon(.bell))
@@ -99,7 +99,7 @@ private extension ContentDetailView {
     }
     
     @ViewBuilder
-    func title(content: ContentDetail.Content) -> some View {
+    func title(content: BaseContentDetail) -> some View {
         VStack(alignment: .leading, spacing: 8) {
             Group {
                 remindAndBadge(content: content)
@@ -127,7 +127,7 @@ private extension ContentDetailView {
     }
     
     @ViewBuilder
-    func contentLinkPreview(content: ContentDetail.Content) -> some View {
+    func contentLinkPreview(content: BaseContentDetail) -> some View {
         VStack(spacing: 16) {
             if let title = store.linkTitle,
                let image = store.linkImage {
@@ -145,7 +145,7 @@ private extension ContentDetailView {
     }
     
     @ViewBuilder
-    func contentMemo(content: ContentDetail.Content) -> some View {
+    func contentMemo(content: BaseContentDetail) -> some View {
         HStack {
             VStack {
                 Text(content.memo)
@@ -167,7 +167,7 @@ private extension ContentDetailView {
     }
     
     @ViewBuilder
-    func favorite(content: ContentDetail.Content) -> some View {
+    func favorite(content: BaseContentDetail) -> some View {
         Button(action: { send(.favoriteButtonTapped, animation: .smooth) }) {
             let isFavorite = content.favorites
             
@@ -180,7 +180,7 @@ private extension ContentDetailView {
     }
     
     @ViewBuilder
-    func bottomToolbar(content: ContentDetail.Content) -> some View {
+    func bottomToolbar(content: BaseContentDetail) -> some View {
         HStack(spacing: 12) {
             favorite(content: content)
             

--- a/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailView.swift
+++ b/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailView.swift
@@ -67,8 +67,8 @@ public extension ContentDetailView {
                     action: { send(.deleteAlertConfirmTapped) }
                 )
             }
-            .onAppear {
-                send(.contentDetailViewOnAppeared, animation: .smooth)
+            .task {
+                await send(.contentDetailViewOnAppeared, animation: .smooth).finish()
             }
         }
     }
@@ -235,7 +235,7 @@ private extension ContentDetailView {
             initialState: .init(
                 contentId: 0
             ),
-            reducer: { ContentDetailFeature() }
+            reducer: { ContentDetailFeature()._printChanges() }
         )
     )
 }

--- a/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailView.swift
+++ b/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailView.swift
@@ -90,7 +90,9 @@ private extension ContentDetailView {
                     }
             }
             
-            PokitBadge(content.categoryName, state: .default)
+            if let categoryName = store.category?.categoryName {
+                PokitBadge(categoryName, state: .default)
+            }
             
             Spacer()
         }

--- a/Projects/Feature/FeatureContentDetailDemo/Sources/FeatureContentDetailDemoApp.swift
+++ b/Projects/Feature/FeatureContentDetailDemo/Sources/FeatureContentDetailDemoApp.swift
@@ -28,7 +28,7 @@ struct FeatureContentDetailDemoApp: App {
             .background(.white)
             .sheet(isPresented: $showLinkDetail) {
                 ContentDetailView(store: .init(
-                    initialState: .init(contentId: 2),
+                    initialState: .init(contentId: 3),
                     reducer: { ContentDetailFeature()._printChanges() })
                 )
             }

--- a/Projects/Feature/FeatureContentDetailDemo/Sources/FeatureContentDetailDemoApp.swift
+++ b/Projects/Feature/FeatureContentDetailDemo/Sources/FeatureContentDetailDemoApp.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-import FeatureLinkDetail
+import FeatureContentDetail
 
 @main
 struct FeatureContentDetailDemoApp: App {
@@ -28,7 +28,7 @@ struct FeatureContentDetailDemoApp: App {
             .background(.white)
             .sheet(isPresented: $showLinkDetail) {
                 ContentDetailView(store: .init(
-                    initialState: .init(contentId: 0),
+                    initialState: .init(contentId: 2),
                     reducer: { ContentDetailFeature()._printChanges() })
                 )
             }

--- a/Projects/Feature/FeatureContentList/Sources/ContentList/ContentListFeature.swift
+++ b/Projects/Feature/FeatureContentList/Sources/ContentList/ContentListFeature.swift
@@ -32,15 +32,15 @@ public struct ContentListFeature {
         
         let contentType: ContentType
         fileprivate var domain = ContentList()
-        var contents: IdentifiedArrayOf<BaseContent> {
-            var identifiedArray = IdentifiedArrayOf<BaseContent>()
+        var contents: IdentifiedArrayOf<BaseContentItem> {
+            var identifiedArray = IdentifiedArrayOf<BaseContentItem>()
             domain.contentList.data.forEach { identifiedArray.append($0) }
             return identifiedArray
         }
         var isListAscending = true
         /// sheet item
-        var bottomSheetItem: BaseContent? = nil
-        var alertItem: BaseContent? = nil
+        var bottomSheetItem: BaseContentItem? = nil
+        var alertItem: BaseContentItem? = nil
     }
     
     /// - Action
@@ -56,13 +56,13 @@ public struct ContentListFeature {
             /// - Binding
             case binding(BindingAction<State>)
             /// - Button Tapped
-            case linkCardTapped(content: BaseContent)
-            case kebabButtonTapped(content: BaseContent)
+            case linkCardTapped(content: BaseContentItem)
+            case kebabButtonTapped(content: BaseContentItem)
             case bottomSheetButtonTapped(
                 delegate: PokitBottomSheet.Delegate,
-                content: BaseContent
+                content: BaseContentItem
             )
-            case deleteAlertConfirmTapped(content: BaseContent)
+            case deleteAlertConfirmTapped(content: BaseContentItem)
             case sortTextLinkTapped
             case backButtonTapped
             /// - On Appeared
@@ -84,7 +84,7 @@ public struct ContentListFeature {
         public enum ScopeAction: Equatable {
             case bottomSheet(
                 delegate: PokitBottomSheet.Delegate,
-                content: BaseContent
+                content: BaseContentItem
             )
         }
         

--- a/Projects/Feature/FeatureContentList/Sources/ContentList/ContentListFeature.swift
+++ b/Projects/Feature/FeatureContentList/Sources/ContentList/ContentListFeature.swift
@@ -90,7 +90,7 @@ public struct ContentListFeature {
         
         public enum DelegateAction: Equatable {
             case 링크상세(content: BaseContentItem)
-            case 링크수정(id: Int)
+            case 링크수정(contentId: Int)
             case linkCopyDetected(URL?)
         }
     }
@@ -233,7 +233,7 @@ private extension ContentListFeature {
                 state.alertItem = content
                 return .none
             case .editCellButtonTapped:
-                return .send(.delegate(.링크수정(id: content.id)))
+                return .send(.delegate(.링크수정(contentId: content.id)))
             case .favoriteCellButtonTapped:
                 return .none
             case .shareCellButtonTapped:

--- a/Projects/Feature/FeatureContentList/Sources/ContentList/ContentListFeature.swift
+++ b/Projects/Feature/FeatureContentList/Sources/ContentList/ContentListFeature.swift
@@ -85,8 +85,8 @@ public struct ContentListFeature {
         }
         
         public enum DelegateAction: Equatable {
-            case 링크상세(content: BaseContent)
-            case 링크수정(content: BaseContent)
+            case 링크상세(contentId: Int)
+            case 링크수정(contentId: Int)
             case linkCopyDetected(URL?)
         }
     }
@@ -133,7 +133,7 @@ private extension ContentListFeature {
             state.bottomSheetItem = content
             return .none
         case .linkCardTapped(let content):
-            return .send(.delegate(.링크상세(content: content)))
+            return .send(.delegate(.링크상세(contentId: content.id)))
         case .bottomSheetButtonTapped(let delegate, let content):
             return .run { send in
                 await send(.inner(.dismissBottomSheet))
@@ -218,7 +218,7 @@ private extension ContentListFeature {
                 state.alertItem = content
                 return .none
             case .editCellButtonTapped:
-                return .send(.delegate(.링크수정(content: content)))
+                return .send(.delegate(.링크수정(contentId: content.id)))
             case .favoriteCellButtonTapped:
                 return .none
             case .shareCellButtonTapped:

--- a/Projects/Feature/FeatureContentList/Sources/ContentList/ContentListFeature.swift
+++ b/Projects/Feature/FeatureContentList/Sources/ContentList/ContentListFeature.swift
@@ -72,13 +72,13 @@ public struct ContentListFeature {
         public enum InnerAction: Equatable {
             case dismissBottomSheet
             case 컨텐츠_목록_조회(BaseContentListInquiry)
-            case 컨텐츠_삭제_반영(contentId: Int)
+            case 컨텐츠_삭제_반영(id: Int)
         }
         
         public enum AsyncAction: Equatable {
             case 읽지않음_컨텐츠_조회
             case 즐겨찾기_링크모음_조회
-            case 컨텐츠_삭제(contentId: Int)
+            case 컨텐츠_삭제(id: Int)
         }
         
         public enum ScopeAction: Equatable {
@@ -90,7 +90,7 @@ public struct ContentListFeature {
         
         public enum DelegateAction: Equatable {
             case 링크상세(content: BaseContentItem)
-            case 링크수정(contentId: Int)
+            case 링크수정(id: Int)
             case linkCopyDetected(URL?)
         }
     }
@@ -146,7 +146,7 @@ private extension ContentListFeature {
         case .deleteAlertConfirmTapped:
             guard let id = state.alertItem?.id else { return .none }
             return .run { [id] send in
-                await send(.async(.컨텐츠_삭제(contentId: id)))
+                await send(.async(.컨텐츠_삭제(id: id)))
             }
         case .binding:
             return .none
@@ -183,7 +183,7 @@ private extension ContentListFeature {
         case .컨텐츠_목록_조회(let contentList):
             state.domain.contentList = contentList
             return .none
-        case .컨텐츠_삭제_반영(contentId: let id):
+        case .컨텐츠_삭제_반영(id: let id):
             state.alertItem = nil
             state.domain.contentList.data.removeAll { $0.id == id }
             return .none
@@ -215,10 +215,10 @@ private extension ContentListFeature {
                 ).toDomain()
                 await send(.inner(.컨텐츠_목록_조회(contentList)))
             }
-        case .컨텐츠_삭제(contentId: let id):
+        case .컨텐츠_삭제(id: let id):
             return .run { [id] send in
                 let _ = try await contentClient.컨텐츠_삭제("\(id)")
-                await send(.inner(.컨텐츠_삭제_반영(contentId: id)), animation: .pokitSpring)
+                await send(.inner(.컨텐츠_삭제_반영(id: id)), animation: .pokitSpring)
             }
         }
     }
@@ -233,7 +233,7 @@ private extension ContentListFeature {
                 state.alertItem = content
                 return .none
             case .editCellButtonTapped:
-                return .send(.delegate(.링크수정(contentId: content.id)))
+                return .send(.delegate(.링크수정(id: content.id)))
             case .favoriteCellButtonTapped:
                 return .none
             case .shareCellButtonTapped:

--- a/Projects/Feature/FeatureContentList/Sources/ContentList/ContentListFeature.swift
+++ b/Projects/Feature/FeatureContentList/Sources/ContentList/ContentListFeature.swift
@@ -89,7 +89,7 @@ public struct ContentListFeature {
         }
         
         public enum DelegateAction: Equatable {
-            case 링크상세(contentId: Int)
+            case 링크상세(content: BaseContentItem)
             case 링크수정(contentId: Int)
             case linkCopyDetected(URL?)
         }
@@ -137,7 +137,7 @@ private extension ContentListFeature {
             state.bottomSheetItem = content
             return .none
         case .linkCardTapped(let content):
-            return .send(.delegate(.링크상세(contentId: content.id)))
+            return .send(.delegate(.링크상세(content: content)))
         case .bottomSheetButtonTapped(let delegate, let content):
             return .run { send in
                 await send(.inner(.dismissBottomSheet))

--- a/Projects/Feature/FeatureContentList/Sources/ContentList/ContentListView.swift
+++ b/Projects/Feature/FeatureContentList/Sources/ContentList/ContentListView.swift
@@ -48,7 +48,7 @@ public extension ContentListView {
                     confirmText: "삭제"
                 ) { send(.deleteAlertConfirmTapped(content: content)) }
             }
-            .onAppear { send(.contentListViewOnAppeared) }
+            .task { await send(.contentListViewOnAppeared).finish() }
         }
     }
 }
@@ -74,7 +74,7 @@ private extension ContentListView {
     var list: some View {
         ScrollView {
             VStack(spacing: 0) {
-                ForEach(store.contents) { content in
+                ForEach(store.contents, id: \.id) { content in
                     let isFirst = content == store.contents.first
                     let isLast = content == store.contents.last
                     

--- a/Projects/Feature/FeatureContentListDemo/Sources/FeatureContentListDemoApp.swift
+++ b/Projects/Feature/FeatureContentListDemo/Sources/FeatureContentListDemoApp.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-import FeatureLinkList
+import FeatureContentList
 
 @main
 struct FeatureContentListDemoApp: App {
@@ -15,8 +15,8 @@ struct FeatureContentListDemoApp: App {
         WindowGroup {
             // TODO: 루트 뷰 추가
             ContentListView(store: .init(
-                initialState: .init(linkType: .unread),
-                reducer: { ContentListFeature() }
+                initialState: .init(contentType: .unread),
+                reducer: { ContentListFeature()._printChanges() }
             ))
         }
     }

--- a/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingFeature.swift
+++ b/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingFeature.swift
@@ -21,14 +21,18 @@ public struct ContentSettingFeature {
     private var linkPresentation
     @Dependency(\.pasteboard)
     private var pasteboard
+    @Dependency(\.contentClient)
+    private var contentClient
+    @Dependency(\.categoryClient)
+    private var categoryClient
     /// - State
     @ObservableState
     public struct State: Equatable {
         public init(
-            content: BaseContent? = nil,
+            contentId: Int? = nil,
             urlText: String? = nil
         ) {
-            self.domain = .init(content: content, data: urlText)
+            self.domain = .init(contentId: contentId, data: urlText)
         }
         fileprivate var domain: ContentSetting
         var urlText: String {
@@ -43,11 +47,11 @@ public struct ContentSettingFeature {
             get { domain.memo }
             set { domain.memo = newValue }
         }
-        var isRemind: BaseContent.RemindState {
+        var isRemind: ContentDetail.Content.RemindState {
             get { domain.alertYn }
             set { domain.alertYn = newValue }
         }
-        var content: BaseContent? {
+        var content: ContentDetail.Content? {
             get { domain.content }
         }
         var pokitList: [BaseCategory] {
@@ -87,16 +91,23 @@ public struct ContentSettingFeature {
             case parsingURL
             case showPopup
             case updateURLText(String?)
+            case 컨텐츠_갱신(content: ContentDetail.Content)
+            case 카테고리_갱신(category: BaseCategoryDetail)
+            case 카테고리_목록_갱신(categoryList: BaseCategoryListInquiry)
         }
 
         public enum AsyncAction: Equatable {
-            case 저장하기_네트워크
+            case 컨텐츠_상세_조회(id: Int)
+            case 카테고리_상세_조회(id: Int)
+            case 카테고리_목록_조회
+            case 컨텐츠_수정
+            case 컨텐츠_추가
         }
 
         public enum ScopeAction: Equatable { case doNothing }
 
         public enum DelegateAction: Equatable {
-            case 저장하기_네트워크이후
+//            case 저장하기_네트워크이후(BaseContent)
             case 포킷추가하기
         }
     }
@@ -155,17 +166,16 @@ private extension ContentSettingFeature {
         case .binding:
             return .none
         case .pokitSelectButtonTapped:
-            return .none
+            return .send(.async(.카테고리_목록_조회))
         case .pokitSelectItemButtonTapped(pokit: let pokit):
             state.selectedPokit = pokit
             return .none
         case .contentSettingViewOnAppeared:
-            // - MARK: 목업 데이터 조회
-            state.domain.categoryListInQuiry = CategoryListInquiryResponse.mock.toDomain()
-            if state.domain.categoryId != nil {
-                state.selectedPokit = CategoryItemInquiryResponse.mock.toDomain()
-            }
-            return .run { send in
+            return .run { [id = state.domain.contentId] send in
+                if let id {
+                    await send(.async(.컨텐츠_상세_조회(id: id)))
+                }
+                await send(.async(.카테고리_목록_조회))
                 await send(.inner(.parsingURL))
                 for await _ in self.pasteboard.changes() {
                     let url = try await pasteboard.probableWebURL()
@@ -173,7 +183,14 @@ private extension ContentSettingFeature {
                 }
             }
         case .saveBottomButtonTapped:
-            return .run { send in await send(.async(.저장하기_네트워크)) }
+            return .run { [isEdit = state.domain.categoryId != nil] send in
+                if isEdit {
+                    await send(.async(.컨텐츠_수정))
+                } else {
+                    await send(.async(.컨텐츠_추가))
+                }
+                await dismiss()
+            }
         case .addPokitButtonTapped:
             guard state.domain.categoryTotalCount < 30 else {
                 /// 🚨 Error Case [1]: 포킷 갯수가 30개 이상일 경우
@@ -219,15 +236,106 @@ private extension ContentSettingFeature {
             guard let urlText else { return .none }
             state.domain.data = urlText
             return .send(.inner(.parsingURL))
+        case .컨텐츠_갱신(content: let content):
+            state.domain.content = content
+            state.domain.data = content.data
+            state.domain.contentId = content.id
+            state.domain.title = content.title
+            state.domain.categoryId = content.categoryId
+            state.domain.memo = content.memo
+            state.domain.alertYn = content.alertYn
+            return .run { [id = content.categoryId] send in
+                await send(.inner(.parsingURL))
+                await send(.async(.카테고리_상세_조회(id: id)))
+            }
+        case .카테고리_갱신(category: let category):
+            state.selectedPokit = .init(
+                id: category.categoryId,
+                userId: 0,
+                categoryName: category.categoryName,
+                categoryImage: category.categoryImage,
+                contentCount: 0
+            )
+            return .none
+        case .카테고리_목록_갱신(categoryList: let categoryList):
+            state.domain.categoryListInQuiry = categoryList
+            return .none
         }
     }
 
     /// - Async Effect
     func handleAsyncAction(_ action: Action.AsyncAction, state: inout State) -> Effect<Action> {
         switch action {
-        case .저장하기_네트워크:
-            //TODO: 저장하기 네트워크 코드작성
-            return .run { send in await send(.delegate(.저장하기_네트워크이후)) }
+        case .컨텐츠_상세_조회(id: let id):
+            return .run { [id] send in
+                let content = try await contentClient.컨텐츠_상세_조회("\(id)").toDomain()
+                await send(.inner(.컨텐츠_갱신(content: content)))
+            }
+        case .카테고리_상세_조회(id: let id):
+            return .run { [id] send in
+                let category = try await categoryClient.카테고리_상세_조회("\(id)").toDomain()
+                await send(.inner(.카테고리_갱신(category: category)))
+            }
+        case .카테고리_목록_조회:
+            return .run { [pageable = state.domain.pageable] send in
+                let categoryList = try await categoryClient.카테고리_목록_조회(
+                    .init(
+                        page: pageable.page,
+                        size: pageable.size,
+                        sort: pageable.sort
+                    )
+                ).toDomain()
+                await send(.inner(.카테고리_목록_갱신(categoryList: categoryList)))
+            }
+        case .컨텐츠_수정:
+            guard let contentId = state.domain.contentId else {
+                return .none
+            }
+            guard let categoryId = state.selectedPokit?.id else {
+                return .none
+            }
+            return .run { [
+                id = contentId,
+                data = state.domain.data,
+                title = state.domain.title,
+                categoryId = categoryId,
+                memo = state.domain.memo,
+                alertYn = state.domain.alertYn
+            ] send in
+                let content = try await contentClient.컨텐츠_수정(
+                    "\(id)",
+                    ContentBaseRequest(
+                        data: data,
+                        title: title,
+                        categoryId: categoryId,
+                        memo: memo,
+                        alertYn: alertYn.rawValue
+                    )
+                ).toDomain()
+//                await send(.delegate(.저장하기_네트워크이후(content)))
+            }
+        case .컨텐츠_추가:
+            guard let categoryId = state.selectedPokit?.id else {
+                return .none
+            }
+            return .run { [
+                data = state.domain.data,
+                title = state.domain.title,
+                categoryId = categoryId,
+                memo = state.domain.memo,
+                alertYn = state.domain.alertYn
+            ] send in
+                let content = try await contentClient.컨텐츠_추가(
+                    ContentBaseRequest(
+                        data: data,
+                        title: title,
+                        categoryId: categoryId,
+                        memo: memo,
+                        alertYn: alertYn.rawValue
+                    )
+                ).toDomain()
+//                await send(.delegate(.저장하기_네트워크이후(content)))
+            }
         }
     }
 

--- a/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingFeature.swift
+++ b/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingFeature.swift
@@ -107,7 +107,7 @@ public struct ContentSettingFeature {
         public enum ScopeAction: Equatable { case doNothing }
 
         public enum DelegateAction: Equatable {
-//            case 저장하기_네트워크이후(BaseContent)
+            case 저장하기_완료
             case 포킷추가하기
         }
     }
@@ -189,7 +189,6 @@ private extension ContentSettingFeature {
                 } else {
                     await send(.async(.컨텐츠_추가))
                 }
-                await dismiss()
             }
         case .addPokitButtonTapped:
             guard state.domain.categoryTotalCount < 30 else {
@@ -302,7 +301,7 @@ private extension ContentSettingFeature {
                 memo = state.domain.memo,
                 alertYn = state.domain.alertYn
             ] send in
-                let content = try await contentClient.컨텐츠_수정(
+                let _ = try await contentClient.컨텐츠_수정(
                     "\(id)",
                     ContentBaseRequest(
                         data: data,
@@ -311,8 +310,8 @@ private extension ContentSettingFeature {
                         memo: memo,
                         alertYn: alertYn.rawValue
                     )
-                ).toDomain()
-//                await send(.delegate(.저장하기_네트워크이후(content)))
+                )
+                await send(.delegate(.저장하기_완료))
             }
         case .컨텐츠_추가:
             guard let categoryId = state.selectedPokit?.id else {
@@ -325,7 +324,7 @@ private extension ContentSettingFeature {
                 memo = state.domain.memo,
                 alertYn = state.domain.alertYn
             ] send in
-                let content = try await contentClient.컨텐츠_추가(
+                let _ = try await contentClient.컨텐츠_추가(
                     ContentBaseRequest(
                         data: data,
                         title: title,
@@ -333,8 +332,8 @@ private extension ContentSettingFeature {
                         memo: memo,
                         alertYn: alertYn.rawValue
                     )
-                ).toDomain()
-//                await send(.delegate(.저장하기_네트워크이후(content)))
+                )
+                await send(.delegate(.저장하기_완료))
             }
         }
     }

--- a/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingFeature.swift
+++ b/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingFeature.swift
@@ -282,7 +282,8 @@ private extension ContentSettingFeature {
                         page: pageable.page,
                         size: pageable.size,
                         sort: pageable.sort
-                    )
+                    ),
+                    true
                 ).toDomain()
                 await send(.inner(.카테고리_목록_갱신(categoryList: categoryList)))
             }

--- a/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingFeature.swift
+++ b/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingFeature.swift
@@ -47,11 +47,11 @@ public struct ContentSettingFeature {
             get { domain.memo }
             set { domain.memo = newValue }
         }
-        var isRemind: ContentDetail.Content.RemindState {
+        var isRemind: BaseContentDetail.RemindState {
             get { domain.alertYn }
             set { domain.alertYn = newValue }
         }
-        var content: ContentDetail.Content? {
+        var content: BaseContentDetail? {
             get { domain.content }
         }
         var pokitList: [BaseCategory] {
@@ -91,7 +91,7 @@ public struct ContentSettingFeature {
             case parsingURL
             case showPopup
             case updateURLText(String?)
-            case 컨텐츠_갱신(content: ContentDetail.Content)
+            case 컨텐츠_갱신(content: BaseContentDetail)
             case 카테고리_갱신(category: BaseCategoryDetail)
             case 카테고리_목록_갱신(categoryList: BaseCategoryListInquiry)
         }

--- a/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingFeature.swift
+++ b/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingFeature.swift
@@ -92,7 +92,7 @@ public struct ContentSettingFeature {
             case showPopup
             case updateURLText(String?)
             case 컨텐츠_갱신(content: BaseContentDetail)
-            case 카테고리_갱신(category: BaseCategoryDetail)
+            case 카테고리_갱신(category: BaseCategory)
             case 카테고리_목록_갱신(categoryList: BaseCategoryListInquiry)
         }
 

--- a/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingFeature.swift
+++ b/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingFeature.swift
@@ -54,10 +54,10 @@ public struct ContentSettingFeature {
         var content: BaseContentDetail? {
             get { domain.content }
         }
-        var pokitList: [BaseCategory] {
+        var pokitList: [BaseCategoryItem] {
             get { domain.categoryListInQuiry.data }
         }
-        var selectedPokit: BaseCategory? = nil
+        var selectedPokit: BaseCategoryItem? = nil
         var linkTitle: String? = nil
         var linkImage: UIImage? = nil
         var showPopup: Bool = false
@@ -77,7 +77,7 @@ public struct ContentSettingFeature {
             case binding(BindingAction<State>)
             /// - Button Tapped
             case pokitSelectButtonTapped
-            case pokitSelectItemButtonTapped(pokit: BaseCategory)
+            case pokitSelectItemButtonTapped(pokit: BaseCategoryItem)
             case contentSettingViewOnAppeared
             case saveBottomButtonTapped
             case addPokitButtonTapped

--- a/Projects/Feature/FeatureContentSettingDemo/Sources/FeatureContentSettingDemoApp.swift
+++ b/Projects/Feature/FeatureContentSettingDemo/Sources/FeatureContentSettingDemoApp.swift
@@ -17,20 +17,7 @@ struct FeatureContentSettingDemoApp: App {
                 ContentSettingView(
                     store: .init(
                         initialState: ContentSettingFeature.State(
-                            content: .init(
-                                id: 0,
-                                categoryName: "미분류",
-                                categoryId: nil,
-                                title: "[playlist] 혼자만의 시간을 갖는다는 것.",
-                                thumbNail: "",
-                                data: "https://www.youtube.com/watch?v=xSTwqKUyM8k",
-                                domain: "youtube",
-                                memo: "일상 생활에서 정신없이 공부하고, 학교 생활을 하다보면 지쳐서 나만의 시간이 필요하다고 느끼는 것 같아요. 온전한 나만의 시간이 가일상 생활에서 정신없이 공부하고, 학교 생활을 하다보면",
-                                createdAt: .now,
-                                isRead: true,
-                                favorites: true,
-                                alertYn: .yes
-                            )
+                            contentId: 4
                         ),
                         reducer: { ContentSettingFeature()._printChanges() }
                     )
@@ -45,7 +32,7 @@ struct FeatureContentSettingDemoApp: App {
         ContentSettingView(
             store: .init(
                 initialState: ContentSettingFeature.State(
-                    content: nil
+                    contentId: nil
                 ),
                 reducer: { ContentSettingFeature()._printChanges() }
             )

--- a/Projects/Feature/FeatureContentSettingDemo/Sources/FeatureContentSettingDemoApp.swift
+++ b/Projects/Feature/FeatureContentSettingDemo/Sources/FeatureContentSettingDemoApp.swift
@@ -11,6 +11,7 @@ import FeatureContentSetting
 
 @main
 struct FeatureContentSettingDemoApp: App {
+    
     var body: some Scene {
         WindowGroup {
             NavigationStack {

--- a/Projects/Feature/FeaturePokit/Sources/PokitRootFeature.swift
+++ b/Projects/Feature/FeaturePokit/Sources/PokitRootFeature.swift
@@ -103,7 +103,7 @@ public struct PokitRootFeature {
             
             case categoryTapped(BaseCategory)
             case 수정하기(BaseCategory)
-            case 링크수정하기(BaseContent)
+            case 링크수정하기(contentId: Int)
             /// 링크상세로 이동
             case contentDetailTapped(BaseContent)
         }
@@ -294,7 +294,7 @@ private extension PokitRootFeature {
                 state.isKebobSheetPresented = false
                 return .run { [item = state.selectedUnclassifiedItem] send in
                     guard let item else { return }
-                    await send(.delegate(.링크수정하기(item)))
+                    await send(.delegate(.링크수정하기(contentId: item.id)))
                 }
                 
             case .folder(.포킷):

--- a/Projects/Feature/FeaturePokit/Sources/PokitRootFeature.swift
+++ b/Projects/Feature/FeaturePokit/Sources/PokitRootFeature.swift
@@ -30,8 +30,8 @@ public struct PokitRootFeature {
             }
             return identifiedArray
         }
-        var unclassifiedContents: IdentifiedArrayOf<BaseContent> {
-            var identifiedArray = IdentifiedArrayOf<BaseContent>()
+        var unclassifiedContents: IdentifiedArrayOf<BaseContentItem> {
+            var identifiedArray = IdentifiedArrayOf<BaseContentItem>()
             domain.unclassifiedContentList.data.forEach { content in
                 identifiedArray.append(content)
             }
@@ -39,7 +39,7 @@ public struct PokitRootFeature {
         }
         
         var selectedKebobItem: BaseCategory?
-        var selectedUnclassifiedItem: BaseContent?
+        var selectedUnclassifiedItem: BaseContentItem?
         
         var isKebobSheetPresented: Bool = false
         var isPokitDeleteSheetPresented: Bool = false
@@ -70,10 +70,10 @@ public struct PokitRootFeature {
             case sortButtonTapped
             /// - Kebob
             case kebobButtonTapped(BaseCategory)
-            case unclassifiedKebobButtonTapped(BaseContent)
+            case unclassifiedKebobButtonTapped(BaseContentItem)
             
             case categoryTapped(BaseCategory)
-            case contentItemTapped(BaseContent)
+            case contentItemTapped(BaseContentItem)
             
             case pokitRootViewOnAppeared
 
@@ -105,7 +105,7 @@ public struct PokitRootFeature {
             case 수정하기(BaseCategory)
             case 링크수정하기(contentId: Int)
             /// 링크상세로 이동
-            case contentDetailTapped(BaseContent)
+            case contentDetailTapped(BaseContentItem)
         }
     }
     

--- a/Projects/Feature/FeaturePokit/Sources/PokitRootFeature.swift
+++ b/Projects/Feature/FeaturePokit/Sources/PokitRootFeature.swift
@@ -103,7 +103,7 @@ public struct PokitRootFeature {
             
             case categoryTapped(BaseCategoryItem)
             case 수정하기(BaseCategoryItem)
-            case 링크수정하기(contentId: Int)
+            case 링크수정하기(id: Int)
             /// 링크상세로 이동
             case contentDetailTapped(BaseContentItem)
         }
@@ -294,7 +294,7 @@ private extension PokitRootFeature {
                 state.isKebobSheetPresented = false
                 return .run { [item = state.selectedUnclassifiedItem] send in
                     guard let item else { return }
-                    await send(.delegate(.링크수정하기(contentId: item.id)))
+                    await send(.delegate(.링크수정하기(id: item.id)))
                 }
                 
             case .folder(.포킷):

--- a/Projects/Feature/FeaturePokit/Sources/PokitRootFeature.swift
+++ b/Projects/Feature/FeaturePokit/Sources/PokitRootFeature.swift
@@ -23,8 +23,8 @@ public struct PokitRootFeature {
         var sortType: PokitRootFilterType = .sort(.최신순)
         
         fileprivate var domain = Pokit()
-        var categories: IdentifiedArrayOf<BaseCategory> {
-            var identifiedArray = IdentifiedArrayOf<BaseCategory>()
+        var categories: IdentifiedArrayOf<BaseCategoryItem> {
+            var identifiedArray = IdentifiedArrayOf<BaseCategoryItem>()
             domain.categoryList.data.forEach { category in
                 identifiedArray.append(category)
             }
@@ -38,7 +38,7 @@ public struct PokitRootFeature {
             return identifiedArray
         }
         
-        var selectedKebobItem: BaseCategory?
+        var selectedKebobItem: BaseCategoryItem?
         var selectedUnclassifiedItem: BaseContentItem?
         
         var isKebobSheetPresented: Bool = false
@@ -69,10 +69,10 @@ public struct PokitRootFeature {
             case filterButtonTapped(PokitRootFilterType.Folder)
             case sortButtonTapped
             /// - Kebob
-            case kebobButtonTapped(BaseCategory)
+            case kebobButtonTapped(BaseCategoryItem)
             case unclassifiedKebobButtonTapped(BaseContentItem)
             
-            case categoryTapped(BaseCategory)
+            case categoryTapped(BaseCategoryItem)
             case contentItemTapped(BaseContentItem)
             
             case pokitRootViewOnAppeared
@@ -101,8 +101,8 @@ public struct PokitRootFeature {
             case alertButtonTapped
             case settingButtonTapped
             
-            case categoryTapped(BaseCategory)
-            case 수정하기(BaseCategory)
+            case categoryTapped(BaseCategoryItem)
+            case 수정하기(BaseCategoryItem)
             case 링크수정하기(contentId: Int)
             /// 링크상세로 이동
             case contentDetailTapped(BaseContentItem)

--- a/Projects/Feature/FeatureRemind/Sources/Remind/RemindFeature.swift
+++ b/Projects/Feature/FeatureRemind/Sources/Remind/RemindFeature.swift
@@ -151,9 +151,9 @@ private extension RemindFeature {
             return .none
         case .remindViewOnAppeared:
             return .run { send in
-                async let _ = send(.async(.오늘의_리마인드_조회))
-                async let _ = send(.async(.읽지않음_컨텐츠_조회))
-                async let _ = send(.async(.즐겨찾기_링크모음_조회))
+                await send(.async(.오늘의_리마인드_조회))
+                await send(.async(.읽지않음_컨텐츠_조회))
+                await send(.async(.즐겨찾기_링크모음_조회))
             }
         }
     }

--- a/Projects/Feature/FeatureRemind/Sources/Remind/RemindFeature.swift
+++ b/Projects/Feature/FeatureRemind/Sources/Remind/RemindFeature.swift
@@ -74,13 +74,13 @@ public struct RemindFeature {
             case 오늘의_리마인드_조회(contents: [BaseContentItem])
             case 읽지않음_컨텐츠_조회(contentList: BaseContentListInquiry)
             case 즐겨찾기_링크모음_조회(contentList: BaseContentListInquiry)
-            case 컨텐츠_삭제_반영(contentId: Int)
+            case 컨텐츠_삭제_반영(id: Int)
         }
         public enum AsyncAction: Equatable {
             case 오늘의_리마인드_조회
             case 읽지않음_컨텐츠_조회
             case 즐겨찾기_링크모음_조회
-            case 컨텐츠_삭제(contentId: Int)
+            case 컨텐츠_삭제(id: Int)
         }
         public enum ScopeAction: Equatable {
             case bottomSheet(
@@ -92,7 +92,7 @@ public struct RemindFeature {
             case 링크상세(content: BaseContentItem)
             case alertButtonTapped
             case searchButtonTapped
-            case 링크수정(contentId: Int)
+            case 링크수정(id: Int)
             case 링크목록_안읽음
             case 링크목록_즐겨찾기
             case 컨텐츠목록_조회
@@ -152,7 +152,7 @@ private extension RemindFeature {
         case .deleteAlertConfirmTapped:
             guard let id = state.alertItem?.id else { return .none }
             return .run { [id] send in
-                await send(.async(.컨텐츠_삭제(contentId: id)))
+                await send(.async(.컨텐츠_삭제(id: id)))
             }
         case .binding:
             return .none
@@ -179,7 +179,7 @@ private extension RemindFeature {
         case .즐겨찾기_링크모음_조회(contentList: let contentList):
             state.domain.favoriteList = contentList
             return .none
-        case .컨텐츠_삭제_반영(contentId: let contentId):
+        case .컨텐츠_삭제_반영(id: let contentId):
             state.alertItem = nil
             state.domain.recommendedList.removeAll { $0.id == contentId }
             state.domain.unreadList.data.removeAll { $0.id == contentId }
@@ -217,10 +217,10 @@ private extension RemindFeature {
                 ).toDomain()
                 await send(.inner(.즐겨찾기_링크모음_조회(contentList: contentList)))
             }
-        case .컨텐츠_삭제(contentId: let id):
+        case .컨텐츠_삭제(id: let id):
             return .run { [id] send in
                 let _ = try await contentClient.컨텐츠_삭제("\(id)")
-                await send(.inner(.컨텐츠_삭제_반영(contentId: id)), animation: .pokitSpring)
+                await send(.inner(.컨텐츠_삭제_반영(id: id)), animation: .pokitSpring)
             }
         }
     }
@@ -234,7 +234,7 @@ private extension RemindFeature {
                 state.alertItem = content
                 return .none
             case .editCellButtonTapped:
-                return .send(.delegate(.링크수정(contentId: content.id)))
+                return .send(.delegate(.링크수정(id: content.id)))
             case .favoriteCellButtonTapped:
                 return .none
             case .shareCellButtonTapped:

--- a/Projects/Feature/FeatureRemind/Sources/Remind/RemindFeature.swift
+++ b/Projects/Feature/FeatureRemind/Sources/Remind/RemindFeature.swift
@@ -25,24 +25,24 @@ public struct RemindFeature {
         public init() {}
         
         fileprivate var domain = Remind()
-        var recommendedContents: IdentifiedArrayOf<BaseContent> {
-            var identifiedArray = IdentifiedArrayOf<BaseContent>()
+        var recommendedContents: IdentifiedArrayOf<BaseContentItem> {
+            var identifiedArray = IdentifiedArrayOf<BaseContentItem>()
             domain.recommendedList.forEach { identifiedArray.append($0) }
             return identifiedArray
         }
-        var unreadContents: IdentifiedArrayOf<BaseContent> {
-            var identifiedArray = IdentifiedArrayOf<BaseContent>()
+        var unreadContents: IdentifiedArrayOf<BaseContentItem> {
+            var identifiedArray = IdentifiedArrayOf<BaseContentItem>()
             domain.unreadList.data.forEach { identifiedArray.append($0) }
             return identifiedArray
         }
-        var favoriteContents: IdentifiedArrayOf<BaseContent> {
-            var identifiedArray = IdentifiedArrayOf<BaseContent>()
+        var favoriteContents: IdentifiedArrayOf<BaseContentItem> {
+            var identifiedArray = IdentifiedArrayOf<BaseContentItem>()
             domain.favoriteList.data.forEach { identifiedArray.append($0) }
             return identifiedArray
         }
         /// sheet item
-        var bottomSheetItem: BaseContent? = nil
-        var alertItem: BaseContent? = nil
+        var bottomSheetItem: BaseContentItem? = nil
+        var alertItem: BaseContentItem? = nil
     }
     /// - Action
     public enum Action: FeatureAction, ViewAction {
@@ -57,21 +57,21 @@ public struct RemindFeature {
             /// - Button Tapped
             case bellButtonTapped
             case searchButtonTapped
-            case linkCardTapped(content: BaseContent)
-            case kebabButtonTapped(content: BaseContent)
+            case linkCardTapped(content: BaseContentItem)
+            case kebabButtonTapped(content: BaseContentItem)
             case unreadNavigationLinkTapped
             case favoriteNavigationLinkTapped
             case bottomSheetButtonTapped(
                 delegate: PokitBottomSheet.Delegate,
-                content: BaseContent
+                content: BaseContentItem
             )
-            case deleteAlertConfirmTapped(content: BaseContent)
+            case deleteAlertConfirmTapped(content: BaseContentItem)
             
             case remindViewOnAppeared
         }
         public enum InnerAction: Equatable {
             case dismissBottomSheet
-            case 오늘의_리마인드_조회(contents: [BaseContent])
+            case 오늘의_리마인드_조회(contents: [BaseContentItem])
             case 읽지않음_컨텐츠_조회(contentList: BaseContentListInquiry)
             case 즐겨찾기_링크모음_조회(contentList: BaseContentListInquiry)
             case 컨텐츠_삭제_반영(contentId: Int)
@@ -85,11 +85,11 @@ public struct RemindFeature {
         public enum ScopeAction: Equatable {
             case bottomSheet(
                 delegate: PokitBottomSheet.Delegate,
-                content: BaseContent
+                content: BaseContentItem
             )
         }
         public enum DelegateAction: Equatable {
-            case 링크상세(content: BaseContent)
+            case 링크상세(content: BaseContentItem)
             case alertButtonTapped
             case searchButtonTapped
             case 링크수정(contentId: Int)

--- a/Projects/Feature/FeatureRemind/Sources/Remind/RemindFeature.swift
+++ b/Projects/Feature/FeatureRemind/Sources/Remind/RemindFeature.swift
@@ -151,9 +151,9 @@ private extension RemindFeature {
             return .none
         case .remindViewOnAppeared:
             return .run { send in
-                await send(.async(.오늘의_리마인드_조회))
-                await send(.async(.읽지않음_컨텐츠_조회))
-                await send(.async(.즐겨찾기_링크모음_조회))
+                async let _ = send(.async(.오늘의_리마인드_조회))
+                async let _ = send(.async(.읽지않음_컨텐츠_조회))
+                async let _ = send(.async(.즐겨찾기_링크모음_조회))
             }
         }
     }

--- a/Projects/Feature/FeatureRemind/Sources/Remind/RemindFeature.swift
+++ b/Projects/Feature/FeatureRemind/Sources/Remind/RemindFeature.swift
@@ -88,9 +88,10 @@ public struct RemindFeature {
             case 링크상세(content: BaseContent)
             case alertButtonTapped
             case searchButtonTapped
-            case 링크수정(content: BaseContent)
+            case 링크수정(contentId: Int)
             case 링크목록_안읽음
             case 링크목록_즐겨찾기
+            case 컨텐츠목록_조회
         }
     }
     /// initiallizer
@@ -216,7 +217,7 @@ private extension RemindFeature {
                 state.alertItem = content
                 return .none
             case .editCellButtonTapped:
-                return .send(.delegate(.링크수정(content: content)))
+                return .send(.delegate(.링크수정(contentId: content.id)))
             case .favoriteCellButtonTapped:
                 return .none
             case .shareCellButtonTapped:
@@ -226,6 +227,19 @@ private extension RemindFeature {
     }
     /// - Delegate Effect
     func handleDelegateAction(_ action: Action.DelegateAction, state: inout State) -> Effect<Action> {
-        return .none
+        switch action {
+        case .링크상세: return .none
+        case .alertButtonTapped: return .none
+        case .searchButtonTapped: return .none
+        case .링크수정: return .none
+        case .링크목록_안읽음: return .none
+        case .링크목록_즐겨찾기: return .none
+        case .컨텐츠목록_조회:
+            return .run { send in
+                await send(.async(.오늘의_리마인드_조회))
+                await send(.async(.읽지않음_컨텐츠_조회))
+                await send(.async(.즐겨찾기_링크모음_조회))
+            }
+        }
     }
 }

--- a/Projects/Feature/FeatureRemind/Sources/Remind/RemindView.swift
+++ b/Projects/Feature/FeatureRemind/Sources/Remind/RemindView.swift
@@ -92,8 +92,6 @@ extension RemindView {
     
     @ViewBuilder
     private func recommendedContentCellLabel(content: BaseContent) -> some View {
-        let date = formatter.string(from: content.createdAt)
-        
         ZStack(alignment: .bottom) {
             AsyncImage(url: .init(string: content.thumbNail)) { image in
                 image
@@ -138,7 +136,7 @@ extension RemindView {
                 }
                 .padding(.top, 4)
                 
-                Text("\(date) • \(content.domain)")
+                Text("\(content.createdAt) • \(content.domain)")
                     .pokitFont(.detail2)
                     .foregroundStyle(.pokit(.text(.tertiary)))
                     .padding(.top, 8)

--- a/Projects/Feature/FeatureRemind/Sources/Remind/RemindView.swift
+++ b/Projects/Feature/FeatureRemind/Sources/Remind/RemindView.swift
@@ -72,7 +72,7 @@ extension RemindView {
             
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 12) {
-                    ForEach(store.recommendedContents) { content in
+                    ForEach(store.recommendedContents, id: \.id) { content in
                         recommendedContentCell(content: content)
                         
                     }
@@ -185,7 +185,7 @@ extension RemindView {
             }
             .padding(.bottom, 16)
             
-            ForEach(store.unreadContents) { content in
+            ForEach(store.unreadContents, id: \.id) { content in
                 let isFirst = content == store.unreadContents.elements.first
                 let isLast = content == store.unreadContents.elements.last
                 
@@ -206,7 +206,7 @@ extension RemindView {
             }
             .padding(.bottom, 16)
             
-            ForEach(store.favoriteContents) { content in
+            ForEach(store.favoriteContents, id: \.id) { content in
                 let isFirst = content == store.favoriteContents.elements.first
                 let isLast = content == store.favoriteContents.elements.last
                 

--- a/Projects/Feature/FeatureRemind/Sources/Remind/RemindView.swift
+++ b/Projects/Feature/FeatureRemind/Sources/Remind/RemindView.swift
@@ -57,7 +57,7 @@ public extension RemindView {
                     confirmText: "삭제"
                 ) { send(.deleteAlertConfirmTapped(content: content)) }
             }
-            .onAppear { send(.remindViewOnAppeared) }
+            .task { await send(.remindViewOnAppeared).finish() }
         }
     }
 }

--- a/Projects/Feature/FeatureRemind/Sources/Remind/RemindView.swift
+++ b/Projects/Feature/FeatureRemind/Sources/Remind/RemindView.swift
@@ -83,7 +83,7 @@ extension RemindView {
     }
     
     @ViewBuilder
-    private func recommendedContentCell(content: BaseContent) -> some View {
+    private func recommendedContentCell(content: BaseContentItem) -> some View {
         Button(action: { send(.linkCardTapped(content: content)) }) {
             recommendedContentCellLabel(content: content)
         }
@@ -91,7 +91,7 @@ extension RemindView {
     }
     
     @ViewBuilder
-    private func recommendedContentCellLabel(content: BaseContent) -> some View {
+    private func recommendedContentCellLabel(content: BaseContentItem) -> some View {
         ZStack(alignment: .bottom) {
             AsyncImage(url: .init(string: content.thumbNail)) { image in
                 image

--- a/Projects/Feature/FeatureSetting/Sources/Search/PokitSearchFeature.swift
+++ b/Projects/Feature/FeatureSetting/Sources/Search/PokitSearchFeature.swift
@@ -46,8 +46,8 @@ public struct PokitSearchFeature {
         var isResultAscending = true
         
         fileprivate var domain = Search()
-        var resultMock: IdentifiedArrayOf<BaseContent> {
-            var identifiedArray = IdentifiedArrayOf<BaseContent>()
+        var resultMock: IdentifiedArrayOf<BaseContentItem> {
+            var identifiedArray = IdentifiedArrayOf<BaseContentItem>()
             domain.contentList.data.forEach { identifiedArray.append($0) }
             return identifiedArray
         }
@@ -69,8 +69,8 @@ public struct PokitSearchFeature {
         }
         
         /// sheet item
-        var bottomSheetItem: BaseContent? = nil
-        var alertItem: BaseContent? = nil
+        var bottomSheetItem: BaseContentItem? = nil
+        var alertItem: BaseContentItem? = nil
     }
     
     /// - Action
@@ -99,13 +99,13 @@ public struct PokitSearchFeature {
             case categoryFilterChipTapped(category: BaseCategory)
             case recentSearchAllRemoveButtonTapped
             case recentSearchChipIconTapped(searchText: String)
-            case linkCardTapped(content: BaseContent)
-            case kebabButtonTapped(content: BaseContent)
+            case linkCardTapped(content: BaseContentItem)
+            case kebabButtonTapped(content: BaseContentItem)
             case bottomSheetButtonTapped(
                 delegate: PokitBottomSheet.Delegate,
-                content: BaseContent
+                content: BaseContentItem
             )
-            case deleteAlertConfirmTapped(content: BaseContent)
+            case deleteAlertConfirmTapped(content: BaseContentItem)
             case sortTextLinkTapped
             case backButtonTapped
             /// - TextInput OnSubmitted
@@ -132,13 +132,13 @@ public struct PokitSearchFeature {
             case filterBottomSheet(FilterBottomFeature.Action.DelegateAction)
             case bottomSheet(
                 delegate: PokitBottomSheet.Delegate,
-                content: BaseContent
+                content: BaseContentItem
             )
         }
         
         public enum DelegateAction: Equatable {
-            case linkCardTapped(content: BaseContent)
-            case bottomSheetEditCellButtonTapped(content: BaseContent)
+            case linkCardTapped(content: BaseContentItem)
+            case bottomSheetEditCellButtonTapped(content: BaseContentItem)
             case linkCopyDetected(URL?)
         }
     }

--- a/Projects/Feature/FeatureSetting/Sources/Search/PokitSearchFeature.swift
+++ b/Projects/Feature/FeatureSetting/Sources/Search/PokitSearchFeature.swift
@@ -41,7 +41,7 @@ public struct PokitSearchFeature {
         var isAutoSaveSearch: Bool = false
         var isSearching: Bool = false
         var isFiltered: Bool = false
-        var categoryFilter = IdentifiedArrayOf<BaseCategory>()
+        var categoryFilter = IdentifiedArrayOf<BaseCategoryItem>()
         var dateFilterText = "기간"
         var isResultAscending = true
         
@@ -96,7 +96,7 @@ public struct PokitSearchFeature {
             case unreadChipTapped
             case dateFilterButtonTapped
             case categoryFilterButtonTapped
-            case categoryFilterChipTapped(category: BaseCategory)
+            case categoryFilterChipTapped(category: BaseCategoryItem)
             case recentSearchAllRemoveButtonTapped
             case recentSearchChipIconTapped(searchText: String)
             case linkCardTapped(content: BaseContentItem)

--- a/Projects/Feature/FeatureSetting/Sources/Search/Sheet/FilterBottomFeature.swift
+++ b/Projects/Feature/FeatureSetting/Sources/Search/Sheet/FilterBottomFeature.swift
@@ -21,7 +21,7 @@ public struct FilterBottomFeature {
     public struct State: Equatable {
         public init(
             filterType currentType: FilterType,
-            pokitFilter selectedPokit: IdentifiedArrayOf<BaseCategory>,
+            pokitFilter selectedPokit: IdentifiedArrayOf<BaseCategoryItem>,
             favoriteFilter isFavorite: Bool,
             unreadFilter isUnread: Bool,
             startDateFilter startDate: Date?,
@@ -38,7 +38,7 @@ public struct FilterBottomFeature {
         
         var currentType: FilterType
         
-        var selectedCategories = IdentifiedArrayOf<BaseCategory>()
+        var selectedCategories = IdentifiedArrayOf<BaseCategoryItem>()
         var isFavorite: Bool
         var isUnread: Bool
         var dateSelected: Bool
@@ -56,7 +56,7 @@ public struct FilterBottomFeature {
         }
         
         fileprivate var domain = FilterBottom()
-        var pokitList: [BaseCategory] {
+        var pokitList: [BaseCategoryItem] {
             get { domain.categoryList.data }
         }
     }
@@ -74,9 +74,9 @@ public struct FilterBottomFeature {
             /// - Binding
             case binding(BindingAction<State>)
             /// - Button Tapped
-            case pokitListCellTapped(pokit: BaseCategory)
+            case pokitListCellTapped(pokit: BaseCategoryItem)
             case searchButtonTapped
-            case pokitChipTapped(BaseCategory)
+            case pokitChipTapped(BaseCategoryItem)
             case favoriteChipTapped
             case unreadChipTapped
             case dateChipTapped
@@ -94,7 +94,7 @@ public struct FilterBottomFeature {
         
         public enum DelegateAction: Equatable {
             case searchButtonTapped(
-                categories: IdentifiedArrayOf<BaseCategory>,
+                categories: IdentifiedArrayOf<BaseCategoryItem>,
                 isFavorite: Bool,
                 isUnread: Bool,
                 startDate: Date?,

--- a/Projects/Util/Sources/Constants.swift
+++ b/Projects/Util/Sources/Constants.swift
@@ -13,6 +13,7 @@ public enum Constants {
     public static let authPath: String = "/api/v1/auth"
     public static let categoryPath: String = "/api/v1/category"
     public static let contentPath: String = "/api/v1/content"
+    public static let remindPath: String = "api/v1/remind"
     
     public static var mockImageUrl: String { "https://picsum.photos/\(Int.random(in: 150...250))" }
 }

--- a/Projects/Util/Sources/Extension/DateFormatter+Extension.swift
+++ b/Projects/Util/Sources/Extension/DateFormatter+Extension.swift
@@ -10,14 +10,14 @@ import Foundation
 public extension DateFormatter {
     static func stringToDate(string: String) -> Date {
         let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy.MM.dd"
+        formatter.dateFormat = "yyyy-MM-ddThh:mm:ss.SSSSSS"
         guard let date = formatter.date(from: string) else { return .now }
         return date
     }
     
     static func dateToString(date: Date) -> String {
         let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy.MM.dd"
+        formatter.dateFormat = "yyyy-MM-ddThh:mm:ss.SSSSSS"
         return formatter.string(from: date)
     }
 }

--- a/Projects/Util/Sources/Extension/DateFormatter+Extension.swift
+++ b/Projects/Util/Sources/Extension/DateFormatter+Extension.swift
@@ -10,14 +10,14 @@ import Foundation
 public extension DateFormatter {
     static func stringToDate(string: String) -> Date {
         let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-ddThh:mm:ss.SSSSSS"
+        formatter.dateFormat = "yyyy.MM.dd"
         guard let date = formatter.date(from: string) else { return .now }
         return date
     }
     
     static func dateToString(date: Date) -> String {
         let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-ddThh:mm:ss.SSSSSS"
+        formatter.dateFormat = "yyyy.MM.dd"
         return formatter.string(from: date)
     }
 }

--- a/Projects/Util/Sources/Protocols/PokitLinkCardItem.swift
+++ b/Projects/Util/Sources/Protocols/PokitLinkCardItem.swift
@@ -10,7 +10,7 @@ import Foundation
 public protocol PokitLinkCardItem {
     var title: String { get }
     var thumbNail: String { get }
-    var createdAt: Date { get }
+    var createdAt: String { get }
     var categoryName: String { get }
     var isRead: Bool { get }
     var data: String { get }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #79 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- Remind api를 위한 RemindClient를 구현하였습니다.
- Remind 기능에 대한 api를 연결하였습니다.
- ContentDetail 기능에 대한 api를 연결하였습니다.
- ContentSetting 기능에 대한 api를 연결하였습니다.
- Content 삭제 api를 연결하였습니다.
- CategoryDetail 기능에 대한 컨텐츠 조회 api를 연결하였습니다.
- Pokit 기능에 대한 미분류 컨텐츠 조회 api를 연결하였습니다.

### 스크린샷 (선택)
![Simulator Screen Recording - iPhone 15 Pro - 2024-08-09 at 17 16 43](https://github.com/user-attachments/assets/1329e00f-071c-40be-9765-3a77eca334d1)

![Simulator Screen Recording - iPhone 15 Pro - 2024-08-09 at 17 11 26](https://github.com/user-attachments/assets/2373998c-f970-4a42-a970-0f74892419e7)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
- 페이징 관리에 대해 이야기 해보면 좋을것 같아요.
- ~~삭제하기 api에서 계속 오류가 나는데 이유를 모르겠어요. 삭제하기 요청은 성공적으로 가는것 같은데, response에서 문제가 자꾸 생깁니다.~~
<img width="799" alt="스크린샷 2024-08-09 17 19 18" src="https://github.com/user-attachments/assets/7d3751f6-697e-41be-b522-c25d835aeb88">

- 화면이동 시 최대한 api호출을 피하고자 노력을 했지만 Content에 대한 데이터 형식들이 기능별로 달라서 어쩔 수 없이 수정하기 화면, 링크 상세화면 이동 시 Content의 id값만 공유하고, Content 상세 호출을 하도록 하였습니다. 추가나 수정한 후에도 목록 재조회를 해야할 것 같아요.
- api에 맞추느라 DTO와 Domain을 좀 손봤습니다.
- 아직 로딩 화면 처리를 안해서 좀 끊기거나 애니메이션이 부자연스러울 수 있습니다.


close #79 
