### PR TITLE
feat: Setting Flow API Connect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,9 @@ fastlane/key.json
 *.ipa
 *.app.dSYM.zip
 
+### Auth Key
+*.p8
+
 ### fastlane environment
 fastlane/.env
 fastlane/.env.default

--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,9 @@ download-privates:
 	@if [ -f "Pokit_iOS_Private/xcconfig/Secret.xcconfig" ]; then \
 		mkdir -p xcconfig; \
 		cp Pokit_iOS_Private/xcconfig/Secret.xcconfig xcconfig/Secret.xcconfig; \
+		cp Pokit_iOS_Private/auth/AuthKey.p8 Projects/CoreKit/Resources/AuthKey.p8; \
 		rm -rf Pokit_iOS_Private; \
-		echo "✅ Secret.xcconfig 파일을 성공적으로 다운로드하고 Pokit_iOS_Private 폴더를 삭제했습니다."; \
+		echo "✅ Secret 파일을 성공적으로 다운로드하고 Pokit_iOS_Private 폴더를 삭제했습니다."; \
 	else \
 		echo "❌ Secret.xcconfig 파일을 찾을 수 없습니다."; \
 	fi

--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -42,7 +42,7 @@ let project = Project(
                 ],
                 configurations: [
                     .debug(name: "Debug", xcconfig: .relativeToRoot("xcconfig/Secret.xcconfig")),
-                    .debug(name: "Release", xcconfig: .relativeToRoot("xcconfig/Secret.xcconfig"))
+                    .release(name: "Release", xcconfig: .relativeToRoot("xcconfig/Secret.xcconfig"))
                 ]
             )
         )

--- a/Projects/App/Resources/Pokit-info.plist
+++ b/Projects/App/Resources/Pokit-info.plist
@@ -33,6 +33,12 @@
 	<string>1</string>
 	<key>GIDClientID</key>
 	<string>$(GIDClientID)</string>
+	<key>AppleKeyID</key>
+	<string>$(AppleKeyID)</string>
+	<key>TeamID</key>
+	<string>$(TeamID)</string>
+	<key>AuthKey</key>
+	<string>$(AuthKey)</string>
 	<key>LSApplicationCategoryType</key>
 	<string></string>
 	<key>LSRequiresIPhoneOS</key>

--- a/Projects/App/Sources/MainTab/MainTabFeature.swift
+++ b/Projects/App/Sources/MainTab/MainTabFeature.swift
@@ -65,6 +65,8 @@ public struct MainTabFeature {
         public enum DelegateAction: Equatable {
             case 링크추가하기
             case 포킷추가하기
+            case 로그아웃
+            case 회원탈퇴
         }
     }
     /// initiallizer

--- a/Projects/App/Sources/MainTab/MainTabPath.swift
+++ b/Projects/App/Sources/MainTab/MainTabPath.swift
@@ -156,6 +156,11 @@ public extension MainTabFeature {
             case .remind(.delegate(.링크목록_즐겨찾기)):
                 state.path.append(.링크목록(ContentListFeature.State(contentType: .favorite)))
                 return .none
+                
+            case .path(.element(_, action: .설정(.delegate(.로그아웃)))):
+                return .send(.delegate(.로그아웃))
+            case .path(.element(_, action: .설정(.delegate(.회원탈퇴)))):
+                return .send(.delegate(.회원탈퇴))
             default: return .none
             }
         }

--- a/Projects/App/Sources/Root/RootFeature.swift
+++ b/Projects/App/Sources/Root/RootFeature.swift
@@ -42,6 +42,16 @@ public struct RootFeature {
             state.intro = nil
             state.mainTab = MainTabFeature.State()
             return .none
+            
+        case .mainTab(.delegate(.로그아웃)):
+            state.intro = .login()
+            state.mainTab = nil
+            return .none
+        case .mainTab(.delegate(.회원탈퇴)):
+            state.intro = .login()
+            state.mainTab = nil
+            return .none
+            
         case .appDelegate, .intro, .mainTab:
             return .none
         }

--- a/Projects/CoreKit/Project.swift
+++ b/Projects/CoreKit/Project.swift
@@ -25,6 +25,7 @@ let coreKit: Target = .target(
     deploymentTargets: .appMinimunTarget,
     infoPlist: .file(path: .relativeToRoot("Projects/App/Resources/Pokit-info.plist")),
     sources: ["Sources/**"],
+    resources: ["Resources/**"],
     dependencies: [
         .project(target: "Util", path: .relativeToRoot("Projects/Util")),
         .project(target: "SharedThirdPartyLib", path: .relativeToRoot("Projects/SharedThirdPartyLib")),

--- a/Projects/CoreKit/Project.swift
+++ b/Projects/CoreKit/Project.swift
@@ -29,9 +29,18 @@ let coreKit: Target = .target(
         .project(target: "Util", path: .relativeToRoot("Projects/Util")),
         .project(target: "SharedThirdPartyLib", path: .relativeToRoot("Projects/SharedThirdPartyLib")),
         .external(name: "Moya"),
-        .external(name: "GoogleSignIn")
+        .external(name: "GoogleSignIn"),
+        .external(name: "SwiftJWT")
     ],
-    settings: .settings
+    settings: .settings(
+        base: [
+            "OTHER_LDFLAGS": "$(inherited) -ObjC",
+        ],
+        configurations: [
+            .debug(name: "Debug", xcconfig: .relativeToRoot("xcconfig/Secret.xcconfig")),
+            .release(name: "Release", xcconfig: .relativeToRoot("xcconfig/Secret.xcconfig"))
+        ]
+    )
 )
 
 let project = Project(

--- a/Projects/CoreKit/Sources/Data/Client/Keychain/KeychainClient.swift
+++ b/Projects/CoreKit/Sources/Data/Client/Keychain/KeychainClient.swift
@@ -12,6 +12,7 @@ import Dependencies
 public enum KeychainKey: String {
     case accessToken
     case refreshToken
+    case serverRefresh
 }
 
 // MARK: - Dependency Values

--- a/Projects/CoreKit/Sources/Data/Client/SocialLogin/Controller/AppleLoginController.swift
+++ b/Projects/CoreKit/Sources/Data/Client/SocialLogin/Controller/AppleLoginController.swift
@@ -104,8 +104,8 @@ extension AppleLoginController {
         
         var myJWT = JWT(header: header, claims: claims)
         let bundle = Bundle(for: type(of: self))
-        guard let authKeyName = Bundle.main.object(forInfoDictionaryKey: "AuthKey") as? String else { return "" }
-        guard let url = bundle.url(forResource: authKeyName, withExtension: "p8") else {
+//        guard let authKeyName = Bundle.main.object(forInfoDictionaryKey: "AuthKey") as? String else { return "" }
+        guard let url = bundle.url(forResource: "AuthKey", withExtension: "p8") else {
             return "못찾음"
         }
         let privateKey: Data = try! Data(contentsOf: url, options: .alwaysMapped)

--- a/Projects/CoreKit/Sources/Data/Client/SocialLogin/Controller/AppleLoginController.swift
+++ b/Projects/CoreKit/Sources/Data/Client/SocialLogin/Controller/AppleLoginController.swift
@@ -7,27 +7,28 @@
 
 import Foundation
 import AuthenticationServices
+import SwiftJWT
 
 public final class AppleLoginController: NSObject, ASAuthorizationControllerDelegate {
-
+    
     private var continuation: CheckedContinuation<SocialLoginInfo, Error>?
-
+    
     public func login() async throws -> SocialLoginInfo {
         try await withCheckedThrowingContinuation { continuation in
             let appleIDProvider = ASAuthorizationAppleIDProvider()
             let request = appleIDProvider.createRequest()
             request.requestedScopes = [.fullName, .email]
-
+            
             let authorizationController = ASAuthorizationController(authorizationRequests: [request])
             authorizationController.delegate = self
             authorizationController.performRequests()
-
+            
             if self.continuation == nil {
                 self.continuation = continuation
             }
         }
     }
-
+    
     public func authorizationController(
         controller: ASAuthorizationController,
         didCompleteWithAuthorization authorization: ASAuthorization
@@ -37,14 +38,15 @@ public final class AppleLoginController: NSObject, ASAuthorizationControllerDele
             continuation = nil
             return
         }
-
+        
+        
         guard let tokenData = credential.identityToken,
               let token = String(data: tokenData, encoding: .utf8) else {
             continuation?.resume(throwing: SocialLoginError.appleLoginError(.invalidIdentityToken))
             continuation = nil
             return
         }
-
+        
         guard let authorizationCode = credential.authorizationCode,
               let codeString = String(data: authorizationCode, encoding: .utf8) else {
             continuation?.resume(throwing: SocialLoginError.appleLoginError(.invalidAuthorizationCode))
@@ -53,20 +55,64 @@ public final class AppleLoginController: NSObject, ASAuthorizationControllerDele
         }
         print("🍎 [appleLogin] token: \(token)")
         print("🍎 [appleLogin] authorizationCode: \(codeString)")
-
+        
+        let secretKey = self.makeJWT()
+        
+        
         let info = SocialLoginInfo(
             idToken: token,
-            provider: .apple
+            provider: .apple,
+            serverRefreshToken: codeString,
+            jwt: secretKey,
+            authCode: codeString
         )
         continuation?.resume(returning: info)
         continuation = nil
     }
-
+    
     public func authorizationController(
         controller: ASAuthorizationController,
         didCompleteWithError error: Error
     ) {
         continuation?.resume(throwing: error)
         continuation = nil
+    }
+}
+
+extension AppleLoginController {
+    func makeJWT() -> String {
+        guard let appleKey = Bundle.main.object(forInfoDictionaryKey: "AppleKeyID") as? String else { return "" }
+        let header = Header(kid: appleKey)
+        struct PokitClaims: Claims {
+            let iss: String
+            let iat: Int
+            let exp: Int
+            let aud: String
+            let sub: String
+        }
+        
+        let iat = Int(Date().timeIntervalSince1970)
+        let exp = iat + 3600
+        guard let iss = Bundle.main.object(forInfoDictionaryKey: "TeamID") as? String else { return "" }
+        let claims = PokitClaims(
+            iss: iss,
+            iat: iat,
+            exp: exp,
+            aud: "https://appleid.apple.com",
+            sub: "com.pokitmons.pokit"
+        )
+        
+        var myJWT = JWT(header: header, claims: claims)
+        let bundle = Bundle(for: type(of: self))
+        guard let authKeyName = Bundle.main.object(forInfoDictionaryKey: "AuthKey") as? String else { return "" }
+        guard let url = bundle.url(forResource: authKeyName, withExtension: "p8") else {
+            return "못찾음"
+        }
+        let privateKey: Data = try! Data(contentsOf: url, options: .alwaysMapped)
+        
+        let jwtSigner = JWTSigner.es256(privateKey: privateKey)
+        let signedJWT = try! myJWT.sign(using: jwtSigner)
+        
+        return signedJWT
     }
 }

--- a/Projects/CoreKit/Sources/Data/Client/SocialLogin/Controller/GoogleLoginController.swift
+++ b/Projects/CoreKit/Sources/Data/Client/SocialLogin/Controller/GoogleLoginController.swift
@@ -40,6 +40,8 @@ public final class GoogleLoginController {
                 return
             }
             
+            let serverRefreshToken = result.user.refreshToken.tokenString
+            
             guard let idToken = result.user.idToken else {
                 continuation?.resume(throwing: SocialLoginError.googleLoginError(.invalidIdToken))
                 continuation = nil
@@ -49,7 +51,10 @@ public final class GoogleLoginController {
 
             let info = SocialLoginInfo(
                 idToken: idToken.tokenString,
-                provider: .google
+                provider: .google,
+                serverRefreshToken: serverRefreshToken,
+                jwt: nil,
+                authCode: nil
             )
             continuation?.resume(returning: info)
         }

--- a/Projects/CoreKit/Sources/Data/Client/SocialLogin/Model/SocialLoginInfo.swift
+++ b/Projects/CoreKit/Sources/Data/Client/SocialLogin/Model/SocialLoginInfo.swift
@@ -10,16 +10,25 @@ import Foundation
 public struct SocialLoginInfo: Equatable {
     public var idToken: String?
     public let provider: SocialLoginProvider
+    public let serverRefreshToken: String
+    public let jwt: String?
+    public let authCode: String?
 }
 
 public extension SocialLoginInfo {
     static let appleMock = SocialLoginInfo(
         idToken: "",
-        provider: .apple
+        provider: .apple, 
+        serverRefreshToken: "",
+        jwt: "",
+        authCode: ""
     )
     
     static let googleMock = SocialLoginInfo(
         idToken: "",
-        provider: .google
+        provider: .google,
+        serverRefreshToken: "",
+        jwt: nil,
+        authCode: nil
     )
 }

--- a/Projects/CoreKit/Sources/Data/Client/UserDefaults/UserDefaultsKey.swift
+++ b/Projects/CoreKit/Sources/Data/Client/UserDefaults/UserDefaultsKey.swift
@@ -14,5 +14,7 @@ public enum UserDefaultsKey {
     public enum StringKey: String {
         /// `구글` or `애플`
         case authPlatform
+        case authCode
+        case jwt
     }
 }

--- a/Projects/CoreKit/Sources/Data/DTO/Auth/AppleTokenRequest.swift
+++ b/Projects/CoreKit/Sources/Data/DTO/Auth/AppleTokenRequest.swift
@@ -1,0 +1,19 @@
+//
+//  AppleTokenRequest.swift
+//  CoreKit
+//
+//  Created by 김민호 on 8/12/24.
+//
+
+import Foundation
+/// Refresh Token을 얻기위한 Request
+public struct AppleTokenRequest: Encodable {
+    public let authCode: String
+    public let jwt: String
+    
+    public init(authCode: String, jwt: String) {
+        self.authCode = authCode
+        self.jwt = jwt
+    }
+}
+

--- a/Projects/CoreKit/Sources/Data/DTO/Auth/AppleTokenResponse.swift
+++ b/Projects/CoreKit/Sources/Data/DTO/Auth/AppleTokenResponse.swift
@@ -1,0 +1,12 @@
+//
+//  AppleTokenResponse.swift
+//  CoreKit
+//
+//  Created by 김민호 on 8/12/24.
+//
+
+import Foundation
+/// Refresh토큰을 받기 위한 Apple Token Response
+public struct AppleTokenResponse: Decodable {
+    public let refresh_token: String
+}

--- a/Projects/CoreKit/Sources/Data/DTO/Auth/WithdrawRequest.swift
+++ b/Projects/CoreKit/Sources/Data/DTO/Auth/WithdrawRequest.swift
@@ -9,6 +9,11 @@ import Foundation
 /// 회원탈퇴 API Request
 /// 📌 회원탈퇴는 Response가 없음
 public struct WithdrawRequest: Encodable {
-    let authorizationCode: String
-    let authPlatform: String
+    public let refreshToken: String
+    public let authPlatform: String
+    
+    public init(refreshToken: String, authPlatform: String) {
+        self.refreshToken = refreshToken
+        self.authPlatform = authPlatform
+    }
 }

--- a/Projects/CoreKit/Sources/Data/DTO/User/NicknameEditRequest.swift
+++ b/Projects/CoreKit/Sources/Data/DTO/User/NicknameEditRequest.swift
@@ -8,5 +8,9 @@
 import Foundation
 /// 닉네임 수정 API Request
 public struct NicknameEditRequest: Encodable {
-    let nickname: String
+    public let nickname: String
+    
+    public init(nickname: String) {
+        self.nickname = nickname
+    }
 }

--- a/Projects/CoreKit/Sources/Data/Network/Auth/AuthClient.swift
+++ b/Projects/CoreKit/Sources/Data/Network/Auth/AuthClient.swift
@@ -22,6 +22,7 @@ public struct AuthClient {
     public var 로그인: @Sendable (SignInRequest) async throws -> TokenResponse
     public var 회원탈퇴: @Sendable (WithdrawRequest) async throws -> Void
     public var 토큰재발급: @Sendable (ReissueRequest) async throws -> ReissueResponse
+    public var apple: @Sendable (AppleTokenRequest) async throws -> AppleTokenResponse
 }
 
 extension AuthClient: DependencyKey {
@@ -39,6 +40,9 @@ extension AuthClient: DependencyKey {
             },
             토큰재발급: { model in
                 try await nonTokenProvider.request(.토큰재발급(model))
+            },
+            apple: { model in
+                try await nonTokenProvider.request(.apple(model))
             }
         )
     }()
@@ -47,7 +51,8 @@ extension AuthClient: DependencyKey {
         Self(
             로그인: { _ in .mock },
             회원탈퇴: { _ in  },
-            토큰재발급: { _ in .mock }
+            토큰재발급: { _ in .mock },
+            apple: { _ in .init(refresh_token: "") }
         )
     }()
 }

--- a/Projects/CoreKit/Sources/Data/Network/Auth/AuthClient.swift
+++ b/Projects/CoreKit/Sources/Data/Network/Auth/AuthClient.swift
@@ -20,7 +20,7 @@ extension DependencyValues {
 /// 유저정보에 관련한 API를 처리하는 Client
 public struct AuthClient {
     public var 로그인: @Sendable (SignInRequest) async throws -> TokenResponse
-    public var 회원탈퇴: @Sendable (WithdrawRequest) async throws -> EmptyResponse
+    public var 회원탈퇴: @Sendable (WithdrawRequest) async throws -> Void
     public var 토큰재발급: @Sendable (ReissueRequest) async throws -> ReissueResponse
 }
 
@@ -35,7 +35,7 @@ extension AuthClient: DependencyKey {
                 try await nonTokenProvider.request(.로그인(model))
             },
             회원탈퇴: { model in
-                try await provider.request(.회원탈퇴(model))
+                try await provider.requestNoBody(.회원탈퇴(model))
             },
             토큰재발급: { model in
                 try await nonTokenProvider.request(.토큰재발급(model))
@@ -46,7 +46,7 @@ extension AuthClient: DependencyKey {
     public static let previewValue: Self = {
         Self(
             로그인: { _ in .mock },
-            회원탈퇴: { _ in .init() },
+            회원탈퇴: { _ in  },
             토큰재발급: { _ in .mock }
         )
     }()

--- a/Projects/CoreKit/Sources/Data/Network/Auth/AuthEndpoint.swift
+++ b/Projects/CoreKit/Sources/Data/Network/Auth/AuthEndpoint.swift
@@ -14,11 +14,17 @@ public enum AuthEndpoint {
     case 로그인(SignInRequest)
     case 회원탈퇴(WithdrawRequest)
     case 토큰재발급(ReissueRequest)
+    case apple(AppleTokenRequest)
 }
 
 extension AuthEndpoint: TargetType {
     public var baseURL: URL {
-        return Constants.serverURL.appendingPathComponent(Constants.authPath, conformingTo: .url)
+        switch self {
+        case .apple:
+            return URL(string: "https://appleid.apple.com/auth/token")!
+        default:
+            return Constants.serverURL.appendingPathComponent(Constants.authPath, conformingTo: .url)
+        }
     }
     
     public var path: String {
@@ -26,12 +32,13 @@ extension AuthEndpoint: TargetType {
         case .로그인: return "/signin"
         case .회원탈퇴: return "/withdraw"
         case .토큰재발급: return "/reissue"
+        case .apple: return ""
         }
     }
     
     public var method: Moya.Method {
         switch self {
-        case .로그인, .토큰재발급: return .post
+        case .로그인, .토큰재발급, .apple: return .post
         case .회원탈퇴: return .put
         }
     }
@@ -46,10 +53,24 @@ extension AuthEndpoint: TargetType {
             
         case let .토큰재발급(requestModel):
             return .requestJSONEncodable(requestModel)
+            
+        case let .apple(requestModel):
+            return .requestParameters(
+                parameters: [
+                    "client_id": "com.pokitmons.pokit",
+                    "client_secret": requestModel.jwt,
+                    "code": requestModel.authCode,
+                    "grant_type": "authorization_code"
+                    ],
+                encoding: URLEncoding.default
+            )
         }
     }
     
     public var headers: [String: String]? {
-        ["Content-Type": "application/json"]
+        switch self {
+        case .apple: ["Content-Type": "application/x-www-form-urlencoded"]
+        default: ["Content-Type": "application/json"]
+        }
     }
 }

--- a/Projects/Feature/FeatureLogin/Sources/RegisterNickname/RegisterNicknameFeature.swift
+++ b/Projects/Feature/FeatureLogin/Sources/RegisterNickname/RegisterNicknameFeature.swift
@@ -105,7 +105,11 @@ private extension RegisterNicknameFeature {
             return .run { send in
                 await send(.inner(.textChanged))
             }
-            .throttle(id: CancelID.response, for: 3.0, scheduler: mainQueue, latest: true)
+            .debounce(
+                id: CancelID.response,
+                for: 3.0,
+                scheduler: mainQueue
+            )
         case .binding:
             return .none
         }

--- a/Projects/Feature/FeatureSetting/Sources/Setting/NickNameSetting/NickNameSettingFeature.swift
+++ b/Projects/Feature/FeatureSetting/Sources/Setting/NickNameSetting/NickNameSettingFeature.swift
@@ -14,6 +14,8 @@ import Util
 public struct NickNameSettingFeature {
     /// - Dependency
     @Dependency(\.dismiss) var dismiss
+    @Dependency(\.userClient) var userClient
+    @Dependency(\.mainQueue) var mainQueue
     /// - State
     @ObservableState
     public struct State: Equatable {
@@ -22,6 +24,8 @@ public struct NickNameSettingFeature {
             get { self.domain.nickname }
             set { self.domain.nickname = newValue }
         }
+        
+        var textfieldState: PokitInputStyle.State = .default
         var buttonState: PokitButtonStyle.State = .disable
         
         public init() {}
@@ -42,9 +46,14 @@ public struct NickNameSettingFeature {
             case saveButtonTapped
         }
         
-        public enum InnerAction: Equatable { case doNothing }
+        public enum InnerAction: Equatable {
+            case textChanged
+            case 닉네임_중복_체크_네트워크_결과(Bool)
+        }
         
-        public enum AsyncAction: Equatable { case doNothing }
+        public enum AsyncAction: Equatable {
+            case 닉네임_중복_체크_네트워크
+        }
         
         public enum ScopeAction: Equatable { case doNothing }
         
@@ -78,7 +87,7 @@ public struct NickNameSettingFeature {
             return handleDelegateAction(delegateAction, state: &state)
         }
     }
-    
+    public enum CancelID { case response }
     /// - Reducer body
     public var body: some ReducerOf<Self> {
         BindingReducer(action: \.view)
@@ -90,6 +99,15 @@ private extension NickNameSettingFeature {
     /// - View Effect
     func handleViewAction(_ action: Action.View, state: inout State) -> Effect<Action> {
         switch action {
+        case .binding(\.text):
+            state.buttonState = .disable
+            return .run { send in
+                await send(.inner(.textChanged))
+            }
+            .debounce(
+                id: CancelID.response,
+                for: 3.0, scheduler: mainQueue
+            )
         case .binding:
             // - MARK: 목업 데이터 조회
             state.domain.isDuplicate = NicknameCheckResponse.mock.toDomain()
@@ -99,18 +117,47 @@ private extension NickNameSettingFeature {
             return .run { _ in await dismiss() }
             
         case .saveButtonTapped:
-            return .none
+            return .run { [nickName = state.text] send in
+                let request = NicknameEditRequest(nickname: nickName)
+                let _ = try await userClient.닉네임_수정(request)
+                await dismiss()
+            }
         }
     }
     
     /// - Inner Effect
     func handleInnerAction(_ action: Action.InnerAction, state: inout State) -> Effect<Action> {
-        return .none
+        switch action {
+        case .textChanged:
+            if state.text.isEmpty || state.text.count > 10 {
+                state.buttonState = .disable
+                return .none
+            } else {
+                return .run { send in
+                    await send(.async(.닉네임_중복_체크_네트워크))
+                }
+            }
+        case let .닉네임_중복_체크_네트워크_결과(isDuplicate):
+            if isDuplicate {
+                state.textfieldState = .error
+                state.buttonState = .disable
+            } else {
+                state.textfieldState = .active
+                state.buttonState = .filled(.primary)
+            }
+            return .none
+        }
     }
     
     /// - Async Effect
     func handleAsyncAction(_ action: Action.AsyncAction, state: inout State) -> Effect<Action> {
-        return .none
+        switch action {
+        case .닉네임_중복_체크_네트워크:
+            return .run { [nickName = state.text] send in
+                let result = try await userClient.닉네임_중복_체크(nickName)
+                await send(.inner(.닉네임_중복_체크_네트워크_결과(result.isDuplicate)))
+            }
+        }
     }
     
     /// - Scope Effect

--- a/Projects/Feature/FeatureSetting/Sources/Setting/NickNameSetting/NickNameSettingView.swift
+++ b/Projects/Feature/FeatureSetting/Sources/Setting/NickNameSetting/NickNameSettingView.swift
@@ -28,19 +28,21 @@ public extension NickNameSettingView {
             VStack(spacing: 0) {
                 PokitTextInput(
                     text: $store.text,
-                    state: .constant(.active),
+                    state: $store.textfieldState,
                     errorMessage: "사용중인 닉네임입니다.",
                     info: "한글, 영어, 숫자로만 입력이 가능합니다.",
                     focusState: $isFocused,
                     equals: true
                 )
                 Spacer()
+            }
+            .overlay(alignment: .bottom) {
                 PokitBottomButton(
                     "저장",
                     state: store.buttonState,
                     action: { send(.saveButtonTapped) }
                 )
-                .padding(.top, 16)
+                .setKeyboardHeight()
             }
             .padding(.top, 16)
             .padding(.horizontal, 20)

--- a/Projects/Feature/FeatureSetting/Sources/Setting/PokitSettingFeature.swift
+++ b/Projects/Feature/FeatureSetting/Sources/Setting/PokitSettingFeature.swift
@@ -19,6 +19,7 @@ public struct PokitSettingFeature {
     @Dependency(\.keychain) var keychain
     @Dependency(\.userDefaults) var userDefaults
     @Dependency(\.authClient) var authClient
+    @Dependency(\.openURL) var openURL
     /// - State
     @ObservableState
     public struct State: Equatable {
@@ -131,16 +132,20 @@ private extension PokitSettingFeature {
             return .run { _ in await openSetting() }
             
         case .공지사항:
-            return .none
+            let url = Constants.공지사항_주소
+            return .run { _ in await openURL(url) }
             
         case .서비스_이용약관:
-            return .none
+            let url = Constants.서비스_이용약관_주소
+            return .run { _ in await openURL(url) }
             
         case .개인정보_처리방침:
-            return .none
+            let url = Constants.개인정보_처리방침_주소
+            return .run { _ in await openURL(url) }
             
         case .고객문의:
-            return .none
+            let url = Constants.고객문의_주소
+            return .run { _ in await openURL(url) }
             
         case .로그아웃:
             return .send(.inner(.로그아웃_팝업(isPresented: true)))

--- a/Projects/Util/Sources/Constants.swift
+++ b/Projects/Util/Sources/Constants.swift
@@ -15,5 +15,11 @@ public enum Constants {
     public static let contentPath: String = "/api/v1/content"
     public static let remindPath: String = "api/v1/remind"
     
+    public static let 공지사항_주소: URL = URL(string: "https://www.naver.com")!
+    public static let 서비스_이용약관_주소: URL = URL(string: "https://www.naver.com")!
+    public static let 개인정보_처리방침_주소: URL = URL(string: "https://www.naver.com")!
+    public static let 고객문의_주소: URL = URL(string: "https://www.naver.com")!
+    
+    
     public static var mockImageUrl: String { "https://picsum.photos/\(Int.random(in: 150...250))" }
 }

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -25,6 +25,7 @@ let package = Package(
         .package(url: "https://github.com/pointfreeco/swift-composable-architecture", from: "1.10.4"),
         .package(url: "https://github.com/google/GoogleSignIn-iOS", "7.0.0" ..< "7.1.0"),
         .package(url: "https://github.com/Moya/Moya", from: "15.0.0"),
-        .package(url: "https://github.com/firebase/firebase-ios-sdk", "10.28.0" ..< "10.28.1")
+        .package(url: "https://github.com/firebase/firebase-ios-sdk", "10.28.0" ..< "10.28.1"),
+        .package(url: "https://github.com/Kitura/Swift-JWT", from: "4.0.1")
     ]
 )


### PR DESCRIPTION
## #️⃣연관된 이슈
#84

## 📝작업 내용
설정창 관련한 API 및 화면연결 작업을 했습니다.
- 닉네임 수정 API 연결
- 회원탈퇴 API 연결
공통: 구글 / 애플 로그인의 회원탈퇴 로직을 추가했습니다. 
애플 회원탈퇴를 위해 애플서버로 직접 요청하는 로직을 추가했습니다. 

이를 위해 Team ID, Key ID, p8파일 등이 필요했으며, 이를 Private Repository로부터 받아옵니다. 기존과 동일하게 `Secret.xcconfig`파일에서 ID값들을 확인할 수 있으며, CoreKit에서도 사용이 되도록 configuration을 수정했습니다.
또한 p8파일도 CoreKit의 Resources에서 관리가 필요할 것 같아 세팅을 수정했습니다.
- 이 외 링크로 이동되는 화면들 연결작업


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)


close #84
