### PR TITLE
fix: QA 반영(08.16)

### DIFF
--- a/Projects/CoreKit/Sources/Data/DTO/Category/BaseCategoryResponse.swift
+++ b/Projects/CoreKit/Sources/Data/DTO/Category/BaseCategoryResponse.swift
@@ -1,0 +1,13 @@
+//
+//  BaseCategoryResponse.swift
+//  CoreKit
+//
+//  Created by 김민호 on 8/16/24.
+//
+
+import Foundation
+
+public struct BaseCategoryResponse: Decodable {
+    public let categoryId: Int
+    public let categoryName: String
+}

--- a/Projects/CoreKit/Sources/Data/DTO/Category/CategoryEditResponse.swift
+++ b/Projects/CoreKit/Sources/Data/DTO/Category/CategoryEditResponse.swift
@@ -35,7 +35,7 @@ extension CategoryImageResponse {
     public static var mock: [Self] = [
         Self(
             imageId: 2312,
-            imageUrl: Constants.mockImageUrl
+            imageUrl: "https://pokit-storage.s3.ap-northeast-2.amazonaws.com/logo/pokit.png"
         ),
         Self(
             imageId: 23122,

--- a/Projects/CoreKit/Sources/Data/DTO/Category/CategoryListInquiryResponse.swift
+++ b/Projects/CoreKit/Sources/Data/DTO/Category/CategoryListInquiryResponse.swift
@@ -24,6 +24,7 @@ public struct CategoryItemInquiryResponse: Decodable {
     public let categoryName: String
     public let categoryImage: CategoryImageResponse
     public let contentCount: Int
+    public let createdAt: String
 }
 /// Sort
 public struct ItemInquirySortResponse: Decodable {
@@ -43,7 +44,8 @@ public extension CategoryItemInquiryResponse {
             imageId: 22312,
             imageUrl: Constants.mockImageUrl
         ),
-        contentCount: 90
+        contentCount: 90,
+        createdAt: ""
     )
 }
 
@@ -58,7 +60,8 @@ extension CategoryListInquiryResponse {
                     imageId: 22312,
                     imageUrl: Constants.mockImageUrl
                 ),
-                contentCount: 90
+                contentCount: 90,
+                createdAt: ""
             ),
             CategoryItemInquiryResponse(
                 categoryId: 2,
@@ -68,7 +71,8 @@ extension CategoryListInquiryResponse {
                     imageId: 22312,
                     imageUrl: Constants.mockImageUrl
                 ),
-                contentCount: 90
+                contentCount: 90,
+                createdAt: ""
             ),
             CategoryItemInquiryResponse(
                 categoryId: 3,
@@ -78,7 +82,8 @@ extension CategoryListInquiryResponse {
                     imageId: 22312,
                     imageUrl: Constants.mockImageUrl
                 ),
-                contentCount: 90
+                contentCount: 90,
+                createdAt: ""
             )
         ],
         page: 1,

--- a/Projects/CoreKit/Sources/Data/DTO/Content/ContentDetailResponse.swift
+++ b/Projects/CoreKit/Sources/Data/DTO/Content/ContentDetailResponse.swift
@@ -9,7 +9,7 @@ import Foundation
 
 public struct ContentDetailResponse: Decodable {
     public let contentId: Int
-    public let categoryId: Int
+    public let category: BaseCategoryResponse
     public let data: String
     public let title: String
     public let memo: String
@@ -21,7 +21,10 @@ public struct ContentDetailResponse: Decodable {
 extension ContentDetailResponse {
     public static var mock: Self = Self(
         contentId: 512,
-        categoryId: 992,
+        category: BaseCategoryResponse(
+            categoryId: 0,
+            categoryName: "카테고리_이름임"
+        ),
         data: "https://www.youtube.com/watch?v=wtSwdGJzQCQ",
         title: "신서유기",
         memo: "#티전드 #신서유기5 #신서유기7 #tvN\n회차정보 : 신서유기5 3회, 신서유기7 1회, 신서유기7 2회, 신서유기7 6회\n\n이제는 전설이 되어버린 역대급 장면들..\n묻지도 따지지도 않고 N회차 재생 가봅시다.",

--- a/Projects/DSKit/Project.swift
+++ b/Projects/DSKit/Project.swift
@@ -24,7 +24,8 @@ let project = Project(
             resources: ["Resources/**"],
             dependencies: [
                 // TODO: 의존성 추가
-                .project(target: "Util", path: .relativeToRoot("Projects/Util"))
+                .project(target: "Util", path: .relativeToRoot("Projects/Util")),
+                .external(name: "NukeUI")
             ]
         )
     ]

--- a/Projects/DSKit/Sources/Components/PokitCard.swift
+++ b/Projects/DSKit/Sources/Components/PokitCard.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 import Util
+import NukeUI
 
 public struct PokitCard<Item: PokitCardItem>: View {
     private let category: Item
@@ -30,6 +31,7 @@ public struct PokitCard<Item: PokitCardItem>: View {
         }
     }
     
+    @MainActor
     private var buttonLabel: some View {
         VStack(spacing: 0) {
             HStack {
@@ -84,11 +86,12 @@ public struct PokitCard<Item: PokitCardItem>: View {
             .pokitFont(.detail2)
             .foregroundStyle(.pokit(.text(.tertiary)))
     }
-    
+
+    @MainActor
     private var thumbNail: some View {
-        AsyncImage(url: .init(string: category.categoryImage.imageURL)) { phase in
+        LazyImage(url: URL(string: category.categoryImage.imageURL)) { state in
             Group {
-                if let image = phase.image {
+                if let image = state.image {
                     image
                         .resizable()
                 } else {
@@ -97,7 +100,7 @@ public struct PokitCard<Item: PokitCardItem>: View {
                         .frame(width: 48, height: 48)
                 }
             }
-            .animation(.smooth, value: phase.image)
+            .animation(.smooth, value: state.image)
         }
         .frame(width: 68, height: 68)
     }

--- a/Projects/DSKit/Sources/Components/PokitLinkCard.swift
+++ b/Projects/DSKit/Sources/Components/PokitLinkCard.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 import Util
+import NukeUI
 
 public struct PokitLinkCard<Item: PokitLinkCardItem>: View {
     private let link: Item
@@ -30,6 +31,7 @@ public struct PokitLinkCard<Item: PokitLinkCardItem>: View {
         }
     }
     
+    @MainActor
     private var buttonLabel: some View {
         HStack(spacing: 12) {
             thumbleNail
@@ -99,8 +101,9 @@ public struct PokitLinkCard<Item: PokitLinkCardItem>: View {
         }
     }
     
+    @MainActor
     private var thumbleNail: some View {
-        AsyncImage(url: .init(string: link.thumbNail)) { phase in
+        LazyImage(url: .init(string: link.thumbNail)) { phase in
             Group {
                 if let image = phase.image {
                     image

--- a/Projects/Domain/Sources/Base/BaseCategoryItem.swift
+++ b/Projects/Domain/Sources/Base/BaseCategoryItem.swift
@@ -15,18 +15,21 @@ public struct BaseCategoryItem: Identifiable, Equatable, PokitSelectItem, PokitC
     public let categoryName: String
     public let categoryImage: BaseCategoryImage
     public var contentCount: Int
+    public let createdAt: String
     
     public init(
         id: Int,
         userId: Int,
         categoryName: String,
         categoryImage: BaseCategoryImage,
-        contentCount: Int
+        contentCount: Int,
+        createdAt: String
     ) {
         self.id = id
         self.userId = userId
         self.categoryName = categoryName
         self.categoryImage = categoryImage
         self.contentCount = contentCount
+        self.createdAt = createdAt
     }
 }

--- a/Projects/Domain/Sources/Base/BaseContentDetail.swift
+++ b/Projects/Domain/Sources/Base/BaseContentDetail.swift
@@ -9,7 +9,7 @@ import Foundation
 
 public struct BaseContentDetail: Equatable {
     public let id: Int
-    public let categoryId: Int
+    public let category: BaseCategoryInfo
     public let title: String
     public let data: String
     public let memo: String
@@ -19,7 +19,7 @@ public struct BaseContentDetail: Equatable {
     
     public init(
         id: Int,
-        categoryId: Int,
+        category: BaseCategoryInfo,
         title: String,
         data: String,
         memo: String,
@@ -28,7 +28,7 @@ public struct BaseContentDetail: Equatable {
         alertYn: RemindState
     ) {
         self.id = id
-        self.categoryId = categoryId
+        self.category = category
         self.title = title
         self.data = data
         self.memo = memo
@@ -43,4 +43,10 @@ public extension BaseContentDetail {
         case yes = "YES"
         case no = "NO"
     }
+}
+
+/// CategoryId & CategoryName
+public struct BaseCategoryInfo: Equatable {
+    public let categoryId: Int
+    public let categoryName: String
 }

--- a/Projects/Domain/Sources/ContentSetting/ContentSetting.swift
+++ b/Projects/Domain/Sources/ContentSetting/ContentSetting.swift
@@ -52,7 +52,7 @@ public struct ContentSetting: Equatable {
         self.pageable = .init(
             page: 0,
             size: 10,
-            sort: ["desc"]
+            sort: ["createdAt", "desc"]
         )
     }
 }

--- a/Projects/Domain/Sources/ContentSetting/ContentSetting.swift
+++ b/Projects/Domain/Sources/ContentSetting/ContentSetting.swift
@@ -46,7 +46,7 @@ public struct ContentSetting: Equatable {
         self.categoryTotalCount = categoryListInquiry.data?.count ?? 0
         self.data = content?.data ?? data ?? ""
         self.title = content?.title ?? ""
-        self.categoryId = content?.categoryId
+        self.categoryId = content?.category.categoryId
         self.memo = content?.memo ?? ""
         self.alertYn = content?.alertYn ?? .no
         self.pageable = .init(

--- a/Projects/Domain/Sources/DTO/Category/CategoryListInquiryResponse+Extention.swift
+++ b/Projects/Domain/Sources/DTO/Category/CategoryListInquiryResponse+Extention.swift
@@ -28,7 +28,8 @@ public extension CategoryItemInquiryResponse {
             userId: self.userId,
             categoryName: self.categoryName,
             categoryImage: self.categoryImage.toDomain(),
-            contentCount: self.contentCount
+            contentCount: self.contentCount,
+            createdAt: self.createdAt
         )
     }
 }

--- a/Projects/Domain/Sources/DTO/Content/ContentDetailResponse+Extension.swift
+++ b/Projects/Domain/Sources/DTO/Content/ContentDetailResponse+Extension.swift
@@ -14,7 +14,10 @@ public extension ContentDetailResponse {
     func toDomain() -> BaseContentDetail {
         return .init(
             id: self.contentId,
-            categoryId: self.categoryId,
+            category: BaseCategoryInfo(
+                categoryId: self.category.categoryId,
+                categoryName: self.category.categoryName
+            ),
             title: self.title,
             data: self.data,
             memo: self.memo,

--- a/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailFeature.swift
+++ b/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailFeature.swift
@@ -38,9 +38,10 @@ public struct CategoryDetailFeature {
             get { domain.condition.isFavoriteFlitered }
         }
         // - TODO: 더 구체적인 처리 필요
-        var sortType: SortType {
-            get { domain.pageable.sort == ["desc"] ? .최신순 : .오래된순 }
-        }
+//        var sortType: SortType {
+//            get { domain.pageable.sort == ["desc"] ? .최신순 : .오래된순 }
+//        }
+        var sortType: SortType = .최신순
         var categories: IdentifiedArrayOf<BaseCategoryItem>? {
             guard let categoryList = domain.categoryListInQuiry.data else {
                 return nil
@@ -354,6 +355,7 @@ private extension CategoryDetailFeature {
                     "createdAt",
                     type == .최신순 ? "desc" : "asc"
                 ]
+                state.sortType = type
                 state.domain.condition.isFavoriteFlitered = bookMarkSelected
                 state.domain.condition.isUnreadFlitered = unReadSelected
                 return .send(.async(.카테고리_내_컨텐츠_목록_조회), animation: .smooth)

--- a/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailView.swift
+++ b/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailView.swift
@@ -194,7 +194,8 @@ private extension CategoryDetailView {
                         userId: 0,
                         categoryName: "포킷",
                         categoryImage: .init(imageId: 0, imageURL: ""),
-                        contentCount: 16
+                        contentCount: 16, 
+                        createdAt: ""
                     )
                 ),
                 reducer: { CategoryDetailFeature() }

--- a/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailView.swift
+++ b/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailView.swift
@@ -63,7 +63,7 @@ public extension CategoryDetailView {
             }
             .sheet(isPresented: $store.isFilterSheetPresented) {
                 CategoryFilterSheet(
-                    sortType: store.sortType,
+                    sortType: $store.sortType,
                     isBookMarkSelected: store.isFavoriteFiltered,
                     isUnreadSeleected: store.isUnreadFiltered,
                     delegateSend: { store.send(.scope(.filterBottomSheet($0))) }

--- a/Projects/Feature/FeatureCategoryDetail/Sources/Sheet/CategoryFilterSheet.swift
+++ b/Projects/Feature/FeatureCategoryDetail/Sources/Sheet/CategoryFilterSheet.swift
@@ -11,18 +11,18 @@ import DSKit
 public struct CategoryFilterSheet: View {
     
     @State private var height: CGFloat = 0
-    @State private var sortType: SortType
+    @Binding private var sortType: SortType
     @State private var isBookMarkSelected: Bool
     @State private var isUnReadSelected: Bool
     private let delegateSend: ((CategoryFilterSheet.Delegate) -> Void)?
     
     public init(
-        sortType: SortType,
+        sortType: Binding<SortType>,
         isBookMarkSelected: Bool,
         isUnreadSeleected: Bool,
         delegateSend: ((CategoryFilterSheet.Delegate) -> Void)?
     ) {
-        self._sortType = .init(initialValue: sortType)
+        self._sortType = sortType
         self._isBookMarkSelected = .init(initialValue: isBookMarkSelected)
         self._isUnReadSelected = .init(initialValue: isUnreadSeleected)
         self.delegateSend = delegateSend
@@ -181,7 +181,7 @@ public extension CategoryFilterSheet {
 //MARK: - Preview
 #Preview {
     CategoryFilterSheet(
-        sortType: .최신순,
+        sortType: .constant(.최신순),
         isBookMarkSelected: true,
         isUnreadSeleected: true,
         delegateSend: nil

--- a/Projects/Feature/FeatureCategorySetting/Sources/PokitCategorySettingFeature.swift
+++ b/Projects/Feature/FeatureCategorySetting/Sources/PokitCategorySettingFeature.swift
@@ -156,7 +156,8 @@ private extension PokitCategorySettingFeature {
             
         case .profileSettingButtonTapped:
             /// [Profile 🎨]1. 프로필 목록 조회 API 호출
-            return .run { send in await send(.async(.프로필_목록_조회)) }
+            state.isProfileSheetPresented.toggle()
+            return .none
 
         case .saveButtonTapped:
             return .run { [domain = state.domain,
@@ -195,6 +196,7 @@ private extension PokitCategorySettingFeature {
                 let pageRequest = BasePageableRequest(page: 0, size: 100, sort: ["desc"])
                 let response = try await categoryClient.카테고리_목록_조회(pageRequest, true).toDomain()
                 await send(.inner(.카테고리_목록_조회_결과(response)))
+                await send(.async(.프로필_목록_조회))
                 
                 for await _ in self.pasteboard.changes() {
                     let url = try await pasteboard.probableWebURL()
@@ -210,8 +212,9 @@ private extension PokitCategorySettingFeature {
         case let .프로필_목록_조회_결과(images):
             /// [Profile 🎨] 2. 프로필 목록들을 profileImages에 할당
             state.domain.imageList = images
+            state.selectedProfile = images.first
             /// [Profile 🎨] 3. 토글 on
-            state.isProfileSheetPresented.toggle()
+//            state.isProfileSheetPresented.toggle()
             return .none
         case let .카테고리_목록_조회_결과(response):
             state.domain.categoryListInQuiry = response

--- a/Projects/Feature/FeatureCategorySetting/Sources/PokitCategorySettingView.swift
+++ b/Projects/Feature/FeatureCategorySetting/Sources/PokitCategorySettingView.swift
@@ -41,6 +41,7 @@ public extension PokitCategorySettingView {
             .pokitNavigationBar(title: store.type.title)
             .sheet(isPresented: $store.isProfileSheetPresented) {
                 ProfileBottomSheet(
+                    selectedImage: store.selectedProfile,
                     images: store.profileImages,
                     delegateSend: { store.send(.scope(.profile($0))) }
                 )

--- a/Projects/Feature/FeatureCategorySetting/Sources/PokitCategorySettingView.swift
+++ b/Projects/Feature/FeatureCategorySetting/Sources/PokitCategorySettingView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 import ComposableArchitecture
 import Domain
 import DSKit
+import NukeUI
 
 @ViewAction(for: PokitCategorySettingFeature.self)
 public struct PokitCategorySettingView: View {
@@ -59,17 +60,17 @@ private extension PokitCategorySettingView {
         }
     }
     /// 썸네일이미지 +프로필 설정
+    @MainActor
     var thumbnailSection: some View {
-        AsyncImage(
+        LazyImage(
             url: URL(string: store.selectedProfile?.imageURL ?? ""),
             transaction: .init(animation: .spring)
         ) { phase in
-            switch phase {
-            case .success(let image):
+            if let image = phase.image {
                 image
                     .resizable()
                     .roundedCorner(12, corners: .allCorners)
-            default:
+            } else {
                 ZStack {
                     Color.pokit(.bg(.disable))
                     

--- a/Projects/Feature/FeatureCategorySetting/Sources/Sheet/ProfileBottomSheet.swift
+++ b/Projects/Feature/FeatureCategorySetting/Sources/Sheet/ProfileBottomSheet.swift
@@ -14,6 +14,7 @@ import NukeUI
 public struct ProfileBottomSheet: View {
     @State private var height: CGFloat = 0
     @State private var images: [BaseCategoryImage]
+    let selectedImage: BaseCategoryImage?
     private let colmumns = [
         GridItem(.fixed(66), spacing: 20),
         GridItem(.fixed(66), spacing: 20),
@@ -22,9 +23,11 @@ public struct ProfileBottomSheet: View {
     private let delegateSend: ((ProfileBottomSheet.Delegate) -> Void)?
     
     public init(
+        selectedImage: BaseCategoryImage?,
         images: [BaseCategoryImage],
         delegateSend: ((ProfileBottomSheet.Delegate) -> Void)?
     ) {
+        self.selectedImage = selectedImage
         self.images = images
         self.delegateSend = delegateSend
     }
@@ -48,6 +51,12 @@ public extension ProfileBottomSheet {
                                     .roundedCorner(12, corners: .allCorners)
                             }
                             .buttonStyle(.plain)
+                            .overlay {
+                                if let selectedImage, item.imageURL == selectedImage.imageURL {
+                                    RoundedRectangle(cornerRadius: 12)
+                                        .stroke(.pokit(.border(.brand)), lineWidth: 2)
+                                }
+                            }
                         } else {
                             PokitSpinner()
                                 .foregroundStyle(.pokit(.icon(.brand)))
@@ -55,6 +64,7 @@ public extension ProfileBottomSheet {
                         }
                     }
                     .frame(width: 66, height: 66)
+                    
                 }
             }
             .padding(.vertical, 12)
@@ -88,6 +98,7 @@ public extension ProfileBottomSheet {
 //MARK: - Preview
 #Preview {
     ProfileBottomSheet(
+        selectedImage: BaseCategoryImage(imageId: 312, imageURL: "https://pokit-storage.s3.ap-northeast-2.amazonaws.com/logo/pokit.png"),
         images: CategoryImageResponse.mock.map { $0.toDomain() },
         delegateSend: nil
     )

--- a/Projects/Feature/FeatureCategorySetting/Sources/Sheet/ProfileBottomSheet.swift
+++ b/Projects/Feature/FeatureCategorySetting/Sources/Sheet/ProfileBottomSheet.swift
@@ -9,6 +9,7 @@ import SwiftUI
 import Domain
 import CoreKit
 import DSKit
+import NukeUI
 
 public struct ProfileBottomSheet: View {
     @State private var height: CGFloat = 0
@@ -31,23 +32,23 @@ public struct ProfileBottomSheet: View {
 }
 //MARK: - View
 public extension ProfileBottomSheet {
+    @MainActor
     var body: some View {
         ScrollView {
             LazyVGrid(columns: colmumns, spacing: 12) {
                 ForEach(images) { item in
-                    AsyncImage(
+                    LazyImage(
                         url: URL(string: item.imageURL),
                         transaction: .init(animation: .smooth)
                     ) { phase in
-                        switch phase {
-                        case .success(let image):
+                        if let image = phase.image {
                             Button(action: { delegateSend?(.imageSelected(item)) }) {
                                 image
                                     .resizable()
                                     .roundedCorner(12, corners: .allCorners)
                             }
                             .buttonStyle(.plain)
-                        default:
+                        } else {
                             PokitSpinner()
                                 .foregroundStyle(.pokit(.icon(.brand)))
                                 .frame(width: 48, height: 48)

--- a/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailFeature.swift
+++ b/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailFeature.swift
@@ -211,7 +211,7 @@ private extension ContentDetailFeature {
             return .run { [id] send in
                 let contentResponse = try await contentClient.컨텐츠_상세_조회("\(id)").toDomain()
                 await send(.inner(.컨텐츠_상세_조회(content: contentResponse)))
-                await send(.async(.카테고리_상세_조회(id: contentResponse.categoryId)))
+                await send(.async(.카테고리_상세_조회(id: contentResponse.category.categoryId)))
             }
         case .즐겨찾기(id: let id):
             return .run { [id] send in

--- a/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingFeature.swift
+++ b/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingFeature.swift
@@ -247,11 +247,11 @@ private extension ContentSettingFeature {
             state.domain.data = content.data
             state.domain.contentId = content.id
             state.domain.title = content.title
-            state.domain.categoryId = content.categoryId
+            state.domain.categoryId = content.category.categoryId
             state.domain.memo = content.memo
             state.domain.alertYn = content.alertYn
             state.contentLoading = false
-            return .run { [id = content.categoryId] send in
+            return .run { [id = content.category.categoryId] send in
                 await send(.inner(.parsingURL))
                 await send(.async(.카테고리_상세_조회(id: id)))
             }

--- a/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingFeature.swift
+++ b/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingFeature.swift
@@ -261,7 +261,8 @@ private extension ContentSettingFeature {
                 userId: 0,
                 categoryName: category.categoryName,
                 categoryImage: category.categoryImage,
-                contentCount: 0
+                contentCount: 0,
+                createdAt: ""
             )
             return .none
         case .카테고리_목록_갱신(categoryList: let categoryList):

--- a/Projects/Feature/FeatureLogin/Sources/RegisterNickname/RegisterNicknameFeature.swift
+++ b/Projects/Feature/FeatureLogin/Sources/RegisterNickname/RegisterNicknameFeature.swift
@@ -107,7 +107,7 @@ private extension RegisterNicknameFeature {
             }
             .debounce(
                 id: CancelID.response,
-                for: 3.0,
+                for: 0.5,
                 scheduler: mainQueue
             )
         case .binding:

--- a/Projects/Feature/FeatureLogin/Sources/RegisterNickname/RegisterNicknameFeature.swift
+++ b/Projects/Feature/FeatureLogin/Sources/RegisterNickname/RegisterNicknameFeature.swift
@@ -118,12 +118,27 @@ private extension RegisterNicknameFeature {
     func handleInnerAction(_ action: Action.InnerAction, state: inout State) -> Effect<Action> {
         switch action {
         case .textChanged:
-            if state.nicknameText == "" || state.nicknameText.count > 10 {
+            /// [1]. 닉네임 텍스트필드가 비어있을 때
+            if state.nicknameText.isEmpty {
                 state.buttonActive = false
                 return .none
+            }
+            /// [2]. 닉네임이 10자를 넘을 때
+            if state.nicknameText.count > 10 {
+                state.buttonActive = false
+                state.textfieldState = .error(message: "최대 10자까지 입력 가능합니다.")
+                return .none
+            }
+            /// [3]. 닉네임에 특수문자가 포함되어 있을 때
+            if !state.nicknameText.isNickNameValid {
+                state.buttonActive = false
+                state.textfieldState = .error(message: "한글, 영어, 숫자만 입력이 가능합니다.")
+                return .none
             } else {
+                /// [4]. 정상 케이스일 때
                 return .run { send in await send(.async(.닉네임_중복_체크_네트워크)) }
             }
+
         case let .닉네임_중복_체크_네트워크_결과(isDuplicate):
             if isDuplicate {
                 state.textfieldState = .error(message: "중복된 닉네임입니다.")

--- a/Projects/Feature/FeaturePokit/Sources/PokitRootFeature.swift
+++ b/Projects/Feature/FeaturePokit/Sources/PokitRootFeature.swift
@@ -270,15 +270,7 @@ private extension PokitRootFeature {
                 /// `포킷`의 최신순 정렬일 때
                 state.folderType == .folder(.포킷)
                 // - TODO: 정렬 조회 필요
-                ? state.domain.categoryList.sort = [
-                    .init(
-                        direction: "",
-                        nullHandling: "",
-                        ascending: true,
-                        property: "",
-                        ignoreCase: false
-                    )
-                ]
+                ? state.domain.categoryList.data?.sort { $0.createdAt < $1.createdAt }
                 : state.domain.unclassifiedContentList.data?.sort { $0.createdAt < $1.createdAt }
             default: return .none
             }

--- a/Projects/Feature/FeatureRemind/Sources/Remind/RemindView.swift
+++ b/Projects/Feature/FeatureRemind/Sources/Remind/RemindView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 import ComposableArchitecture
 import Domain
 import DSKit
+import NukeUI
 import Util
 
 @ViewAction(for: RemindFeature.self)
@@ -135,16 +136,18 @@ extension RemindView {
     @ViewBuilder
     private func recommendedContentCellLabel(content: BaseContentItem) -> some View {
         ZStack(alignment: .bottom) {
-            AsyncImage(url: .init(string: content.thumbNail)) { image in
-                image
-                    .resizable()
-            } placeholder: {
-                ZStack {
-                    Color.pokit(.bg(.disable))
-                    
-                    PokitSpinner()
-                        .foregroundStyle(.pokit(.icon(.brand)))
-                        .frame(width: 48, height: 48)
+            LazyImage(url: .init(string: content.thumbNail)) { phase in
+                if let image = phase.image {
+                    image
+                        .resizable()
+                } else {
+                    ZStack {
+                        Color.pokit(.bg(.disable))
+                        
+                        PokitSpinner()
+                            .foregroundStyle(.pokit(.icon(.brand)))
+                            .frame(width: 48, height: 48)
+                    }
                 }
             }
             

--- a/Projects/Feature/FeatureSetting/Sources/Setting/NickNameSetting/NickNameSettingFeature.swift
+++ b/Projects/Feature/FeatureSetting/Sources/Setting/NickNameSetting/NickNameSettingFeature.swift
@@ -27,7 +27,6 @@ public struct NickNameSettingFeature {
         
         var textfieldState: PokitInputStyle.State = .default
         var buttonState: PokitButtonStyle.State = .disable
-        var textInpuState: PokitInputStyle.State = .default
         
         public init() {}
     }
@@ -130,13 +129,25 @@ private extension NickNameSettingFeature {
     func handleInnerAction(_ action: Action.InnerAction, state: inout State) -> Effect<Action> {
         switch action {
         case .textChanged:
-            if state.text.isEmpty || state.text.count > 10 {
+            /// [1]. 닉네임 텍스트필드가 비어있을 때
+            if state.text.isEmpty {
                 state.buttonState = .disable
                 return .none
+            }
+            /// [2]. 닉네임이 10자를 넘을 때
+            if state.text.count > 10 {
+                state.buttonState = .disable
+                state.textfieldState = .error(message: "최대 10자까지 입력 가능합니다.")
+                return .none
+            }
+            /// [3]. 닉네임에 특수문자가 포함되어 있을 때
+            if !state.text.isNickNameValid {
+                state.buttonState = .disable
+                state.textfieldState = .error(message: "한글, 영어, 숫자만 입력이 가능합니다.")
+                return .none
             } else {
-                return .run { send in
-                    await send(.async(.닉네임_중복_체크_네트워크))
-                }
+                /// [4]. 정상 케이스일 때
+                return .run { send in await send(.async(.닉네임_중복_체크_네트워크)) }
             }
         case let .닉네임_중복_체크_네트워크_결과(isDuplicate):
             if isDuplicate {

--- a/Projects/Feature/FeatureSetting/Sources/Setting/NickNameSetting/NickNameSettingFeature.swift
+++ b/Projects/Feature/FeatureSetting/Sources/Setting/NickNameSetting/NickNameSettingFeature.swift
@@ -106,7 +106,8 @@ private extension NickNameSettingFeature {
             }
             .debounce(
                 id: CancelID.response,
-                for: 3.0, scheduler: mainQueue
+                for: 0.5,
+                scheduler: mainQueue
             )
         case .binding:
             // - MARK: 목업 데이터 조회

--- a/Projects/Feature/FeatureSetting/Sources/Setting/NickNameSetting/NickNameSettingView.swift
+++ b/Projects/Feature/FeatureSetting/Sources/Setting/NickNameSetting/NickNameSettingView.swift
@@ -28,8 +28,9 @@ public extension NickNameSettingView {
             VStack(spacing: 0) {
                 PokitTextInput(
                     text: $store.text,
-                    state: $store.textInpuState,
+                    state: $store.textfieldState,
                     info: "한글, 영어, 숫자로만 입력이 가능합니다.",
+                    maxLetter: 10,
                     focusState: $isFocused,
                     equals: true
                 )

--- a/Projects/Util/Sources/Extension/String+Extension.swift
+++ b/Projects/Util/Sources/Extension/String+Extension.swift
@@ -1,0 +1,17 @@
+//
+//  String+Extension.swift
+//  Util
+//
+//  Created by 김민호 on 8/16/24.
+//
+
+import Foundation
+
+public extension String {
+    /// 영어, 숫자, 한글로만 이루어져있는지 체크
+    var isNickNameValid: Bool {
+        let regex = "^[a-zA-Z0-9가-힣]+$"
+        let predicate = NSPredicate(format: "SELF MATCHES %@", regex)
+        return predicate.evaluate(with: self)
+    }
+}

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -26,6 +26,7 @@ let package = Package(
         .package(url: "https://github.com/google/GoogleSignIn-iOS", "7.0.0" ..< "7.1.0"),
         .package(url: "https://github.com/Moya/Moya", from: "15.0.0"),
         .package(url: "https://github.com/firebase/firebase-ios-sdk", "10.28.0" ..< "10.28.1"),
-        .package(url: "https://github.com/Kitura/Swift-JWT", from: "4.0.1")
+        .package(url: "https://github.com/Kitura/Swift-JWT", from: "4.0.1"),
+        .package(url: "https://github.com/kean/Nuke", from: "12.8.0")
     ]
 )


### PR DESCRIPTION
## #️⃣연관된 이슈

#92 

## 📝작업 내용

QA 수정사항입니다.

- 정렬 최신순 수정
- 카테고리상세 필터 고장 수정
- 이미지캐싱 (AsyncImage -> Nuke)
- 프로필선택 default Image Pokie로 수정
- 이미지 선택 시 이전에 선택한 이미지 테두리 추가
- 링크 추가 시 카테고리 목록에 미분류 최상단에 위치하게 추가
- 닉네임 특수문자 에러처리 수정
- 닉네임 처리 debounce 3sec -> 0.5 sec 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

지금까지 나온것중에 하나빼고 다 수정했습니다.
컨텐츠 상세에서삭제 수정 시 이전화면에 반영되게 하는 흐름은 저번에 한번 설명드렸던 것 같아요. 이부분은 좀 얘기를 나눠야 할 것 같기 때문에 내일 만나서 같이 해보면 좋을 것 같습니다. 
