### PR TITLE
부모 <-> 자식 뷰 간 필요한 delegate 정의

### DIFF
--- a/Projects/App/Sources/AppDelegate/AppDelegate.swift
+++ b/Projects/App/Sources/AppDelegate/AppDelegate.swift
@@ -12,8 +12,8 @@ import FirebaseMessaging
 import GoogleSignIn
 
 final class AppDelegate: NSObject {
-    let store = Store(initialState: RootFeature.State()) {
-        RootFeature()
+    let store = Store(initialState: AppDelegateFeature.State()) {
+        AppDelegateFeature()
     }
 }
 //MARK: - UIApplicationDelegate
@@ -28,7 +28,7 @@ extension AppDelegate: UIApplicationDelegate {
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
-        self.store.send(.appDelegate(.didFinishLaunching))
+        self.store.send((.didFinishLaunching))
         return true
     }
     
@@ -40,9 +40,9 @@ extension AppDelegate: UIApplicationDelegate {
         Messaging.messaging().apnsToken = deviceToken
         Messaging.messaging().token { token, error in
             if let error {
-                self.store.send(.appDelegate(.didRegisterForRemoteNotifications(.failure(error))))
+                self.store.send((.didRegisterForRemoteNotifications(.failure(error))))
             } else if let token {
-                self.store.send(.appDelegate(.didRegisterForRemoteNotifications(.success(token))))
+                self.store.send((.didRegisterForRemoteNotifications(.success(token))))
             }
         }
     }
@@ -52,6 +52,6 @@ extension AppDelegate: UIApplicationDelegate {
         _ application: UIApplication,
         didFailToRegisterForRemoteNotificationsWithError error: any Error
     ) {
-        self.store.send(.appDelegate(.didRegisterForRemoteNotifications(.failure(error))))
+        self.store.send(.didRegisterForRemoteNotifications(.failure(error)))
     }
 }

--- a/Projects/App/Sources/AppDelegate/AppDelegate.swift
+++ b/Projects/App/Sources/AppDelegate/AppDelegate.swift
@@ -28,7 +28,7 @@ extension AppDelegate: UIApplicationDelegate {
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
-        self.store.send((.didFinishLaunching))
+        self.store.send(.didFinishLaunching)
         return true
     }
     
@@ -40,9 +40,9 @@ extension AppDelegate: UIApplicationDelegate {
         Messaging.messaging().apnsToken = deviceToken
         Messaging.messaging().token { token, error in
             if let error {
-                self.store.send((.didRegisterForRemoteNotifications(.failure(error))))
+                self.store.send(.didRegisterForRemoteNotifications(.failure(error)))
             } else if let token {
-                self.store.send((.didRegisterForRemoteNotifications(.success(token))))
+                self.store.send(.didRegisterForRemoteNotifications(.success(token)))
             }
         }
     }

--- a/Projects/App/Sources/AppDelegate/AppDelegateFeature.swift
+++ b/Projects/App/Sources/AppDelegate/AppDelegateFeature.swift
@@ -15,7 +15,10 @@ public struct AppDelegateFeature {
     @Dependency(\.userNotifications) var userNotifications
     @Dependency(\.remoteNotifications.register) var registerForRemoteNotifications
     
-    public struct State: Equatable {
+    @ObservableState
+    public struct State {
+        public var root = RootFeature.State()
+        
         public init() {}
     }
     
@@ -23,11 +26,15 @@ public struct AppDelegateFeature {
         case didFinishLaunching
         case didRegisterForRemoteNotifications(Result<String, Error>)
         case userNotifications(UserNotificationClient.DelegateEvent)
+        case root(RootFeature.Action)
     }
     
     public init() {}
     
     public var body: some ReducerOf<Self> {
+        Scope(state: \.root, action: \.root) {
+            RootFeature()
+        }
         Reduce { state, action in
             switch action {
             case .didFinishLaunching:
@@ -68,6 +75,9 @@ public struct AppDelegateFeature {
             case let .userNotifications(.willPresentNotification(_, completionHandler)):
                 return .run { _ in completionHandler(.banner) }
             case .userNotifications:
+                return .none
+                
+            case .root:
                 return .none
             }
         }

--- a/Projects/App/Sources/AppDelegate/AppDelegateFeature.swift
+++ b/Projects/App/Sources/AppDelegate/AppDelegateFeature.swift
@@ -17,7 +17,7 @@ public struct AppDelegateFeature {
     
     @ObservableState
     public struct State {
-        public var root = RootFeature.State()
+        public var root = RootFeature.State.intro(.splash(.init()))
         
         public init() {}
     }

--- a/Projects/App/Sources/AppDelegate/AppDelegateFeature.swift
+++ b/Projects/App/Sources/AppDelegate/AppDelegateFeature.swift
@@ -17,7 +17,7 @@ public struct AppDelegateFeature {
     
     @ObservableState
     public struct State {
-        public var root = RootFeature.State.intro(.splash(.init()))
+        public var root = RootFeature.State()
         
         public init() {}
     }

--- a/Projects/App/Sources/MainTab/MainTabPath.swift
+++ b/Projects/App/Sources/MainTab/MainTabPath.swift
@@ -126,6 +126,11 @@ public extension MainTabFeature {
                 state.contentDetail = nil
                 // - TODO: 컨텐츠 상세를 띄운 뷰에 컨텐츠 삭제 반영
                 return .none
+            
+            /// - 컨텐츠 상세보기 닫힘
+            case .contentDetail(.dismiss):
+                guard state.path.isEmpty else { return .none }
+                return .send(.remind(.delegate(.컨텐츠목록_조회)))
 
             case let .inner(.링크추가및수정이동(contentId: id)):
                 state.path.append(.링크추가및수정(
@@ -142,7 +147,25 @@ public extension MainTabFeature {
             /// - 링크추가 및 수정에서 저장하기 눌렀을 때
             case .path(.element(_, action: .링크추가및수정(.delegate(.저장하기_완료)))):
                 state.path.removeLast()
-                return .send(.remind(.delegate(.컨텐츠목록_조회)))
+                guard let stackElementId = state.path.ids.last else {
+                    return .send(.remind(.delegate(.컨텐츠목록_조회)))
+                }
+                switch state.path.last {
+                case .링크목록:
+                    return .send(.path(.element(
+                        id: stackElementId,
+                        action: .링크목록(.delegate(.컨텐츠_목록_조회))
+                    )))
+                case .카테고리상세:
+                    return .send(.path(.element(
+                        id: stackElementId,
+                        action: .카테고리상세(.delegate(.카테고리_내_컨텐츠_목록_조회))
+                    )))
+                case nil:
+                     return .send(.remind(.delegate(.컨텐츠목록_조회)))
+                default:
+                    return .none
+                }
             /// - 각 화면에서 링크 복사 감지했을 때 (링크 추가 및 수정 화면 제외)
             case let .path(.element(_, action: .알림함(.delegate(.linkCopyDetected(url))))),
                  let .path(.element(_, action: .검색(.delegate(.linkCopyDetected(url))))),

--- a/Projects/App/Sources/MainTab/MainTabPath.swift
+++ b/Projects/App/Sources/MainTab/MainTabPath.swift
@@ -129,7 +129,9 @@ public extension MainTabFeature {
             
             /// - 컨텐츠 상세보기 닫힘
             case .contentDetail(.dismiss):
-                guard state.path.isEmpty else { return .none }
+                guard state.path.isEmpty && state.selectedTab == .remind else {
+                    return .none
+                }
                 return .send(.remind(.delegate(.컨텐츠목록_조회)))
 
             case let .inner(.링크추가및수정이동(contentId: id)):
@@ -147,22 +149,22 @@ public extension MainTabFeature {
             /// - 링크추가 및 수정에서 저장하기 눌렀을 때
             case .path(.element(_, action: .링크추가및수정(.delegate(.저장하기_완료)))):
                 state.path.removeLast()
-                guard let stackElementId = state.path.ids.last else {
-                    return .send(.remind(.delegate(.컨텐츠목록_조회)))
+                guard let stackElementId = state.path.ids.last,
+                      let lastPath = state.path.last else {
+                    switch state.selectedTab {
+                    case .pokit:
+                        return .send(.pokit(.delegate(.카테고리_또는_컨텐츠_조회)))
+                    case .remind:
+                        return .send(.remind(.delegate(.컨텐츠목록_조회)))
+                    }
                 }
-                switch state.path.last {
+                switch lastPath {
                 case .링크목록:
-                    return .send(.path(.element(
-                        id: stackElementId,
-                        action: .링크목록(.delegate(.컨텐츠_목록_조회))
-                    )))
+                    return .send(.path(.element(id: stackElementId, action: .링크목록(.delegate(.컨텐츠_목록_조회)))))
                 case .카테고리상세:
-                    return .send(.path(.element(
-                        id: stackElementId,
-                        action: .카테고리상세(.delegate(.카테고리_내_컨텐츠_목록_조회))
-                    )))
-                case nil:
-                     return .send(.remind(.delegate(.컨텐츠목록_조회)))
+                    return .send(.path(.element(id: stackElementId, action: .카테고리상세(.delegate(.카테고리_내_컨텐츠_목록_조회)))))
+                case .검색:
+                    return .send(.path(.element(id: stackElementId, action: .검색(.delegate(.컨텐츠_검색)))))
                 default:
                     return .none
                 }

--- a/Projects/App/Sources/MainTab/MainTabPath.swift
+++ b/Projects/App/Sources/MainTab/MainTabPath.swift
@@ -108,7 +108,7 @@ public extension MainTabFeature {
                  let .remind(.delegate(.링크상세(content))),
                  let .path(.element(_, action: .링크목록(.delegate(.링크상세(content: content))))),
                  let .path(.element(_, action: .검색(.delegate(.linkCardTapped(content: content))))):
-                // TODO: 링크상세 모델과 링크수정 모델 일치시키기
+                
                 state.contentDetail = ContentDetailFeature.State(contentId: content.id)
                 return .none
 
@@ -121,11 +121,6 @@ public extension MainTabFeature {
                  let .path(.element(_, action: .검색(.delegate(.링크수정(id))))),
                  let .path(.element(_, action: .알림함(.delegate(.moveToContentEdit(id))))):
                 return .run { send in await send(.inner(.링크추가및수정이동(contentId: id))) }
-                
-            case let .contentDetail(.presented(.delegate(.컨텐츠_삭제_완료(contentId: id)))):
-                state.contentDetail = nil
-                // - TODO: 컨텐츠 상세를 띄운 뷰에 컨텐츠 삭제 반영
-                return .none
             
             /// - 컨텐츠 상세보기 닫힘
             case .contentDetail(.dismiss):
@@ -133,7 +128,7 @@ public extension MainTabFeature {
                       let lastPath = state.path.last else {
                     switch state.selectedTab {
                     case .pokit:
-                        return .none
+                        return .send(.pokit(.delegate(.미분류_카테고리_컨텐츠_조회)))
                     case .remind:
                         return .send(.remind(.delegate(.컨텐츠목록_조회)))
                     }
@@ -145,16 +140,14 @@ public extension MainTabFeature {
                     return .send(.path(.element(id: stackElementId, action: .검색(.delegate(.컨텐츠_검색)))))
                 case .카테고리상세:
                     return .send(.path(.element(id: stackElementId, action: .카테고리상세(.delegate(.카테고리_내_컨텐츠_목록_조회)))))
-                default:
-                    return .none
+                default: return .none
                 }
 
             case let .inner(.링크추가및수정이동(contentId: id)):
                 state.path.append(.링크추가및수정(
                     ContentSettingFeature.State(contentId: id)
                 ))
-                state.contentDetail = nil
-                return .none
+                return .send(.contentDetail(.dismiss))
 
             /// - 링크 추가하기
             case .delegate(.링크추가하기):
@@ -162,11 +155,8 @@ public extension MainTabFeature {
                 return .none
 
             /// - 링크추가 및 수정에서 저장하기 눌렀을 때
-            case .path(.element(_, action: .링크추가및수정(.delegate(.저장하기_완료)))):
+            case let .path(.element(stackElementId, action: .링크추가및수정(.delegate(.저장하기_완료)))):
                 state.path.removeLast()
-                guard let stackElementId = state.path.ids.last else {
-                    return .none
-                }
                 switch state.path.last {
                 case .검색:
                     return .send(.path(.element(id: stackElementId, action: .검색(.delegate(.컨텐츠_검색)))))

--- a/Projects/App/Sources/MainTab/MainTabPath.swift
+++ b/Projects/App/Sources/MainTab/MainTabPath.swift
@@ -129,10 +129,25 @@ public extension MainTabFeature {
             
             /// - 컨텐츠 상세보기 닫힘
             case .contentDetail(.dismiss):
-                guard state.path.isEmpty && state.selectedTab == .remind else {
+                guard let stackElementId = state.path.ids.last,
+                      let lastPath = state.path.last else {
+                    switch state.selectedTab {
+                    case .pokit:
+                        return .none
+                    case .remind:
+                        return .send(.remind(.delegate(.컨텐츠목록_조회)))
+                    }
+                }
+                switch lastPath {
+                case .링크목록:
+                    return .send(.path(.element(id: stackElementId, action: .링크목록(.delegate(.컨텐츠_목록_조회)))))
+                case .검색:
+                    return .send(.path(.element(id: stackElementId, action: .검색(.delegate(.컨텐츠_검색)))))
+                case .카테고리상세:
+                    return .send(.path(.element(id: stackElementId, action: .카테고리상세(.delegate(.카테고리_내_컨텐츠_목록_조회)))))
+                default:
                     return .none
                 }
-                return .send(.remind(.delegate(.컨텐츠목록_조회)))
 
             case let .inner(.링크추가및수정이동(contentId: id)):
                 state.path.append(.링크추가및수정(
@@ -149,20 +164,10 @@ public extension MainTabFeature {
             /// - 링크추가 및 수정에서 저장하기 눌렀을 때
             case .path(.element(_, action: .링크추가및수정(.delegate(.저장하기_완료)))):
                 state.path.removeLast()
-                guard let stackElementId = state.path.ids.last,
-                      let lastPath = state.path.last else {
-                    switch state.selectedTab {
-                    case .pokit:
-                        return .send(.pokit(.delegate(.카테고리_또는_컨텐츠_조회)))
-                    case .remind:
-                        return .send(.remind(.delegate(.컨텐츠목록_조회)))
-                    }
+                guard let stackElementId = state.path.ids.last else {
+                    return .none
                 }
-                switch lastPath {
-                case .링크목록:
-                    return .send(.path(.element(id: stackElementId, action: .링크목록(.delegate(.컨텐츠_목록_조회)))))
-                case .카테고리상세:
-                    return .send(.path(.element(id: stackElementId, action: .카테고리상세(.delegate(.카테고리_내_컨텐츠_목록_조회)))))
+                switch state.path.last {
                 case .검색:
                     return .send(.path(.element(id: stackElementId, action: .검색(.delegate(.컨텐츠_검색)))))
                 default:

--- a/Projects/App/Sources/PokitApp.swift
+++ b/Projects/App/Sources/PokitApp.swift
@@ -7,15 +7,17 @@
 
 import SwiftUI
 
+import ComposableArchitecture
+
 @main
 struct PokitApp: App {
     
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+    var store: StoreOf<AppDelegateFeature> { appDelegate.store }
+    
     var body: some Scene {
         WindowGroup {
-            /// - appDelegate.store -> RootFeature
-            /// - 헷갈리지 않기
-            RootView(store: self.appDelegate.store)
+            RootView(store: store.scope(state: \.root, action: \.root))
         }
     }
 }

--- a/Projects/App/Sources/Root/RootFeature.swift
+++ b/Projects/App/Sources/Root/RootFeature.swift
@@ -11,17 +11,10 @@ import ComposableArchitecture
 
 @Reducer
 public struct RootFeature {
-    @Reducer(state: .equatable)
-    public enum Destination {
-        
-    }
-    
     @ObservableState
     public enum State {
-        case intro(IntroFeature.State = .init())
-        case mainTab(MainTabFeature.State = .init())
-        
-        public init() { self = .intro() }
+        case intro(IntroFeature.State)
+        case mainTab(MainTabFeature.State)
     }
     
     public indirect enum Action {
@@ -38,11 +31,11 @@ public struct RootFeature {
             state = newState
             return .none
         case .intro(.delegate(.moveToTab)):
-            return .run { send in await send(._sceneChange(.mainTab())) }
+            return .send(._sceneChange(.mainTab(.init())))
             
         case .mainTab(.delegate(.로그아웃)),
              .mainTab(.delegate(.회원탈퇴)):
-            return .run { send in await send(._sceneChange(.intro(.login()))) }
+            return .send(._sceneChange(.intro(.login(.init()))))
             
         case .intro, .mainTab:
             return .none

--- a/Projects/App/Sources/Root/RootFeature.swift
+++ b/Projects/App/Sources/Root/RootFeature.swift
@@ -11,10 +11,17 @@ import ComposableArchitecture
 
 @Reducer
 public struct RootFeature {
+    @Reducer(state: .equatable)
+    public enum Destination {
+        
+    }
+    
     @ObservableState
     public enum State {
-        case intro(IntroFeature.State)
-        case mainTab(MainTabFeature.State)
+        case intro(IntroFeature.State = .init())
+        case mainTab(MainTabFeature.State = .init())
+        
+        public init() { self = .intro() }
     }
     
     public indirect enum Action {
@@ -31,11 +38,11 @@ public struct RootFeature {
             state = newState
             return .none
         case .intro(.delegate(.moveToTab)):
-            return .send(._sceneChange(.mainTab(.init())))
+            return .run { send in await send(._sceneChange(.mainTab())) }
             
         case .mainTab(.delegate(.로그아웃)),
-             .mainTab(.delegate(.회원탈퇴)):
-            return .send(._sceneChange(.intro(.login(.init()))))
+                .mainTab(.delegate(.회원탈퇴)):
+            return .run { send in await send(._sceneChange(.intro(.login()))) }
             
         case .intro, .mainTab:
             return .none
@@ -44,8 +51,8 @@ public struct RootFeature {
     /// - Reducer body
     public var body: some ReducerOf<Self> {
         Reduce(self.core)
-        .ifCaseLet(\.intro, action: \.intro) { IntroFeature() }
-        .ifCaseLet(\.mainTab, action: \.mainTab) { MainTabFeature() }
-        ._printChanges()
+            .ifCaseLet(\.intro, action: \.intro) { IntroFeature() }
+            .ifCaseLet(\.mainTab, action: \.mainTab) { MainTabFeature() }
+            ._printChanges()
     }
 }

--- a/Projects/App/Sources/Root/RootView.swift
+++ b/Projects/App/Sources/Root/RootView.swift
@@ -23,12 +23,15 @@ extension RootView {
     public var body: some View {
         WithPerceptionTracking {
             Group {
-                if let store = store.scope(state: \.intro, action: \.intro) {
-                    IntroView(store: store)
-                }
-                
-                if let store = store.scope(state: \.mainTab, action: \.mainTab) {
-                    MainTabView(store: store)
+                switch store.state {
+                case .intro:
+                    if let store = store.scope(state: \.intro, action: \.intro) {
+                        IntroView(store: store)
+                    }
+                case .mainTab:
+                    if let store = store.scope(state: \.mainTab, action: \.mainTab) {
+                        MainTabView(store: store)
+                    }
                 }
             }
             .background(.pokit(.bg(.base)))

--- a/Projects/App/Sources/Root/RootView.swift
+++ b/Projects/App/Sources/Root/RootView.swift
@@ -46,7 +46,7 @@ extension RootView {}
 #Preview {
     RootView(
         store: Store(
-            initialState: .init(),
+            initialState: RootFeature.State.intro(.splash(.init())),
             reducer: { RootFeature() }
         )
     )

--- a/Projects/App/Sources/Root/RootView.swift
+++ b/Projects/App/Sources/Root/RootView.swift
@@ -46,7 +46,7 @@ extension RootView {}
 #Preview {
     RootView(
         store: Store(
-            initialState: RootFeature.State.intro(.splash(.init())),
+            initialState: .init(),
             reducer: { RootFeature() }
         )
     )

--- a/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailFeature.swift
+++ b/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailFeature.swift
@@ -124,6 +124,7 @@ public struct CategoryDetailFeature {
             case 포킷삭제
             case 포킷수정(BaseCategoryItem)
             case 포킷공유
+            case 카테고리_내_컨텐츠_목록_조회
         }
     }
     
@@ -365,6 +366,11 @@ private extension CategoryDetailFeature {
     
     /// - Delegate Effect
     func handleDelegateAction(_ action: Action.DelegateAction, state: inout State) -> Effect<Action> {
-        return .none
+        switch action {
+        case .카테고리_내_컨텐츠_목록_조회:
+            return .send(.async(.카테고리_내_컨텐츠_목록_조회))
+        default:
+            return .none
+        }
     }
 }

--- a/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailView.swift
+++ b/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailView.swift
@@ -136,22 +136,26 @@ private extension CategoryDetailView {
                         
                         Spacer()
                     }
-                }
-                ScrollView(showsIndicators: false) {
-                    ForEach(contents) { content in
-                        let isFirst = content == contents.first
-                        let isLast = content == contents.last
-                        
-                        PokitLinkCard(
-                            link: content,
-                            action: { send(.contentItemTapped(content)) },
-                            kebabAction: { send(.categoryKebobButtonTapped(.링크삭제, selectedItem: content)) }
-                        )
-                        .divider(isFirst: isFirst, isLast: isLast)
-                        .pokitScrollTransition(.opacity)
+                } else {
+                    ScrollView(showsIndicators: false) {
+                        LazyVStack(spacing: 0) {
+                            ForEach(contents) { content in
+                                let isFirst = content == contents.first
+                                let isLast = content == contents.last
+                                
+                                PokitLinkCard(
+                                    link: content,
+                                    action: { send(.contentItemTapped(content)) },
+                                    kebabAction: { send(.categoryKebobButtonTapped(.링크삭제, selectedItem: content)) }
+                                )
+                                .divider(isFirst: isFirst, isLast: isLast)
+                                .pokitScrollTransition(.opacity)
+                            }
+                            
+                            Spacer()
+                        }
                     }
                 }
-                .animation(.spring, value: contents.elements)
             } else {
                 PokitLoading()
             }

--- a/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailView.swift
+++ b/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailView.swift
@@ -69,7 +69,7 @@ public extension CategoryDetailView {
                     delegateSend: { store.send(.scope(.filterBottomSheet($0))) }
                 )
             }
-            .onAppear { send(.onAppear) }
+            .task { await send(.onAppear).finish() }
         }
     }
 }

--- a/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailFeature.swift
+++ b/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailFeature.swift
@@ -203,28 +203,28 @@ private extension ContentDetailFeature {
     func handleAsyncAction(_ action: Action.AsyncAction, state: inout State) -> Effect<Action> {
         switch action {
         case .컨텐츠_상세_조회(id: let id):
-            return .run { [id] send in
+            return .run { send in
                 let contentResponse = try await contentClient.컨텐츠_상세_조회("\(id)").toDomain()
                 await send(.inner(.컨텐츠_상세_조회(content: contentResponse)))
                 await send(.async(.카테고리_상세_조회(id: contentResponse.category.categoryId)))
             }
         case .즐겨찾기(id: let id):
-            return .run { [id] send in
+            return .run { send in
                 let _ = try await contentClient.즐겨찾기("\(id)")
                 await send(.inner(.즐겨찾기_갱신(true)))
             }
         case .즐겨찾기_취소(id: let id):
-            return .run { [id] send in
+            return .run { send in
                 let _ = try await contentClient.즐겨찾기_취소("\(id)")
                 await send(.inner(.즐겨찾기_갱신(false)))
             }
         case .카테고리_상세_조회(id: let id):
-            return .run { [id] send in
+            return .run { send in
                 let category = try await categoryClient.카테고리_상세_조회("\(id)").toDomain()
                 await send(.inner(.카테고리_갱신(category)))
             }
         case .컨텐츠_삭제(id: let id):
-            return .run { [id] _ in
+            return .run { _ in
                 try await contentClient.컨텐츠_삭제("\(id)")
                 await dismiss()
             }

--- a/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailFeature.swift
+++ b/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailFeature.swift
@@ -84,7 +84,6 @@ public struct ContentDetailFeature {
         
         public enum DelegateAction: Equatable {
             case editButtonTapped(contentId: Int)
-            case 컨텐츠_삭제_완료(contentId: Int)
         }
     }
     
@@ -142,8 +141,6 @@ private extension ContentDetailFeature {
             return .none
         case .deleteAlertConfirmTapped:
             return .run { [id = state.domain.contentId] send in
-                //TODO: 링크 삭제
-                await send(.inner(.dismissAlert))
                 await send(.async(.컨텐츠_삭제(id: id)))
             }
         case .binding:
@@ -227,9 +224,9 @@ private extension ContentDetailFeature {
                 await send(.inner(.카테고리_갱신(category)))
             }
         case .컨텐츠_삭제(id: let id):
-            return .run { [id] send in
-                let _ = try await contentClient.컨텐츠_삭제("\(id)")
-                await send(.delegate(.컨텐츠_삭제_완료(contentId: id)))
+            return .run { [id] _ in
+                try await contentClient.컨텐츠_삭제("\(id)")
+                await dismiss()
             }
         }
     }

--- a/Projects/Feature/FeatureContentList/Sources/ContentList/ContentListFeature.swift
+++ b/Projects/Feature/FeatureContentList/Sources/ContentList/ContentListFeature.swift
@@ -102,6 +102,7 @@ public struct ContentListFeature {
             case 링크상세(content: BaseContentItem)
             case 링크수정(contentId: Int)
             case linkCopyDetected(URL?)
+            case 컨텐츠_목록_조회
         }
     }
     
@@ -276,7 +277,17 @@ private extension ContentListFeature {
     
     /// - Delegate Effect
     func handleDelegateAction(_ action: Action.DelegateAction, state: inout State) -> Effect<Action> {
-        return .none
+        switch action {
+        case .컨텐츠_목록_조회:
+            switch state.contentType {
+            case .favorite:
+                return .send(.async(.즐겨찾기_링크모음_조회))
+            case .unread:
+                return .send(.async(.읽지않음_컨텐츠_조회))
+            }
+        default:
+            return .none
+        }
     }
 }
 

--- a/Projects/Feature/FeaturePokit/Sources/PokitRootFeature.swift
+++ b/Projects/Feature/FeaturePokit/Sources/PokitRootFeature.swift
@@ -105,6 +105,7 @@ public struct PokitRootFeature {
             case 미분류_카테고리_컨텐츠_갱신(contentList: BaseContentListInquiry)
             case 분류_페이지네이션_결과(contentList: BaseCategoryListInquiry)
             case 미분류_페이지네이션_결과(contentList: BaseContentListInquiry)
+            case 컨텐츠_삭제(contentId: Int)
         }
         
         public enum AsyncAction: Equatable {
@@ -128,6 +129,7 @@ public struct PokitRootFeature {
             case 링크수정하기(id: Int)
             /// 링크상세로 이동
             case contentDetailTapped(BaseContentItem)
+            case 미분류_카테고리_컨텐츠_조회
         }
     }
     
@@ -303,6 +305,13 @@ private extension PokitRootFeature {
             state.domain.unclassifiedContentList = contentList
             state.domain.unclassifiedContentList.data = list
             return .none
+        case let .컨텐츠_삭제(contentId: contentId):
+            guard let index = state.domain.unclassifiedContentList.data?.firstIndex(where: { $0.id == contentId }) else {
+                return .none
+            }
+            state.domain.unclassifiedContentList.data?.remove(at: index)
+            state.isPokitDeleteSheetPresented = false
+            return .none
         }
     }
     
@@ -413,12 +422,8 @@ private extension PokitRootFeature {
                     /// 🚨 Error Case [1]: 항목을 삭제하려는데 항목이 없을 때
                     return .none
                 }
-                guard let index = state.domain.unclassifiedContentList.data?.firstIndex(of: selectedItem) else {
-                    return .none
-                }
-                state.domain.unclassifiedContentList.data?.remove(at: index)
-                state.isPokitDeleteSheetPresented = false
-                return .none
+                
+                return .send(.inner(.컨텐츠_삭제(contentId: selectedItem.id)))
                 
             case .folder(.포킷):
                 guard let selectedItem = state.selectedKebobItem else {
@@ -440,6 +445,11 @@ private extension PokitRootFeature {
     
     /// - Delegate Effect
     func handleDelegateAction(_ action: Action.DelegateAction, state: inout State) -> Effect<Action> {
-        return .none
+        switch action {
+        case .미분류_카테고리_컨텐츠_조회:
+            return .send(.async(.미분류_카테고리_컨텐츠_조회))
+        default:
+            return .none
+        }
     }
 }

--- a/Projects/Feature/FeaturePokit/Sources/PokitRootFeature.swift
+++ b/Projects/Feature/FeaturePokit/Sources/PokitRootFeature.swift
@@ -128,6 +128,7 @@ public struct PokitRootFeature {
             case 링크수정하기(id: Int)
             /// 링크상세로 이동
             case contentDetailTapped(BaseContentItem)
+            case 카테고리_또는_컨텐츠_조회
         }
     }
     
@@ -434,6 +435,16 @@ private extension PokitRootFeature {
     
     /// - Delegate Effect
     func handleDelegateAction(_ action: Action.DelegateAction, state: inout State) -> Effect<Action> {
-        return .none
+        switch action {
+        case .카테고리_또는_컨텐츠_조회:
+            switch state.folderType {
+            case .folder(.미분류):
+                return .send(.async(.미분류_카테고리_컨텐츠_조회))
+            case .folder(.포킷):
+                return .send(.async(.목록조회_갱신용))
+            default: return .none
+            }
+        default: return .none
+        }
     }
 }

--- a/Projects/Feature/FeaturePokit/Sources/PokitRootFeature.swift
+++ b/Projects/Feature/FeaturePokit/Sources/PokitRootFeature.swift
@@ -128,7 +128,6 @@ public struct PokitRootFeature {
             case 링크수정하기(id: Int)
             /// 링크상세로 이동
             case contentDetailTapped(BaseContentItem)
-            case 카테고리_또는_컨텐츠_조회
         }
     }
     
@@ -213,7 +212,13 @@ private extension PokitRootFeature {
         case .contentItemTapped(let selectedItem):
             return .run { send in await send(.delegate(.contentDetailTapped(selectedItem))) }
         case .pokitRootViewOnAppeared:
-            return .run { send in await send(.async(.목록조회_갱신용)) }
+            switch state.folderType {
+            case .folder(.미분류):
+                return .send(.async(.미분류_카테고리_컨텐츠_조회))
+            case .folder(.포킷):
+                return .send(.async(.목록조회_갱신용))
+            default: return .none
+            }
         case .분류_pagenation:
             if state.domain.categoryList.hasNext {
                 return .run { [domain = state.domain.categoryList,
@@ -435,16 +440,6 @@ private extension PokitRootFeature {
     
     /// - Delegate Effect
     func handleDelegateAction(_ action: Action.DelegateAction, state: inout State) -> Effect<Action> {
-        switch action {
-        case .카테고리_또는_컨텐츠_조회:
-            switch state.folderType {
-            case .folder(.미분류):
-                return .send(.async(.미분류_카테고리_컨텐츠_조회))
-            case .folder(.포킷):
-                return .send(.async(.목록조회_갱신용))
-            default: return .none
-            }
-        default: return .none
-        }
+        return .none
     }
 }

--- a/Projects/Feature/FeatureRemind/Sources/Remind/RemindFeature.swift
+++ b/Projects/Feature/FeatureRemind/Sources/Remind/RemindFeature.swift
@@ -254,18 +254,13 @@ private extension RemindFeature {
     /// - Delegate Effect
     func handleDelegateAction(_ action: Action.DelegateAction, state: inout State) -> Effect<Action> {
         switch action {
-        case .링크상세: return .none
-        case .alertButtonTapped: return .none
-        case .searchButtonTapped: return .none
-        case .링크수정: return .none
-        case .링크목록_안읽음: return .none
-        case .링크목록_즐겨찾기: return .none
         case .컨텐츠목록_조회:
             return .run { send in
                 await send(.async(.오늘의_리마인드_조회))
                 await send(.async(.읽지않음_컨텐츠_조회))
                 await send(.async(.즐겨찾기_링크모음_조회))
             }
+        default: return .none
         }
     }
 }

--- a/Projects/Feature/FeatureSetting/Sources/Search/PokitSearchFeature.swift
+++ b/Projects/Feature/FeatureSetting/Sources/Search/PokitSearchFeature.swift
@@ -161,6 +161,7 @@ public struct PokitSearchFeature {
             case linkCardTapped(content: BaseContentItem)
             case 링크수정(contentId: Int)
             case linkCopyDetected(URL?)
+            case 컨텐츠_검색
         }
     }
     
@@ -496,6 +497,10 @@ private extension PokitSearchFeature {
     
     /// - Delegate Effect
     func handleDelegateAction(_ action: Action.DelegateAction, state: inout State) -> Effect<Action> {
-        return .none
+        switch action {
+        case .컨텐츠_검색:
+            return .send(.async(.컨텐츠_검색))
+        default: return .none
+        }
     }
 }

--- a/Projects/Feature/FeatureSetting/Sources/Search/PokitSearchView.swift
+++ b/Projects/Feature/FeatureSetting/Sources/Search/PokitSearchView.swift
@@ -63,7 +63,7 @@ public extension PokitSearchView {
                     confirmText: "삭제"
                 ) { send(.deleteAlertConfirmTapped) }
             }
-            .onAppear { send(.onAppear) }
+            .task { await send(.onAppear).finish() }
         }
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #98 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- ContentDetail에 `dismiss` 발동될 시점의 `delegate` 연결
- ContentSetting에 `저장하기_완료` 발동될 시점의 `delegate` 연결
- @stealmh RootFeature의 store 관리를 개선해 주셨습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 로그아웃, 회원탈퇴도 그렇고, 이번 ContentDetail 쪽 작업을 하면서 아래와 같은 경고문을 마주하였습니다.
```
An "ifLet" at "App/MainTabFeature.swift:113" received a presentation action when destination state was absent. …

  Action:
    MainTabFeature.Action.contentDetail(.presented(.delegate(.컨텐츠_삭제_완료(contentId:))))

This is generally considered an application logic error, and can happen for a few reasons:

• A parent reducer set destination state to "nil" before this reducer ran. This reducer must run before any other reducer sets destination state to "nil". This ensures that destination reducers can handle their actions while their state is still present.

• This action was sent to the store while destination state was "nil". Make sure that actions for this reducer can only be sent from a view store when state is present, or from effects that start from this reducer. In SwiftUI applications, use a Composable Architecture view modifier like "sheet(store:…)".
```
ContentDetail 시트를 닫을 때 ContentDetail의 `store`를 그대로 `nil`로 박아버린게 원인이었고, 지금은 ContentDetail 내부에서 `dimiss`액션을 실행하도록 수정하고, MainTabFeature에서 감지하도록 수정하였습니다.
```swift
 /// - 컨텐츠 상세보기 닫힘
 case .contentDetail(.dismiss):
...
```
- 위와 같은 이유로 로그아웃, 회원탈퇴도 @stealmh 께서 `ifLet`에서  `ifCaseLet`으로 `store`를 열거형으로 바꿔주셨으나 경고문은 여전하였습니다. 위와 같은 경고문은  자식 `store`의 액션이 끝나지 않은 상태에서 부모 `store`가 먼저 사라져 버려서 나는 경고문이기 때문에, `ifCaseLet`을 쓰는게 맞는거 같고, 기술문서에도` ifCaseLet`을 쓰면, `store` 열거형이 바뀌었을 때, 모든 자식 액션들을 취소해준다고 나와있긴합니다. (근데 왜 이러는지...)
<img width="741" alt="스크린샷 2024-08-20 17 06 32" src="https://github.com/user-attachments/assets/f24d7d0c-38ef-44d9-a286-646ea65d73ba">

- 일단 작성해주신 방법이 더 안정적인거 같아 그대로 반영하겠습니다.


close #98 
