### PR TITLE
QA: 커스텀 네비게이션 바 전환

### DIFF
--- a/Projects/App/Sources/MainTab/MainTabFeatureView.swift
+++ b/Projects/App/Sources/MainTab/MainTabFeatureView.swift
@@ -136,16 +136,12 @@ private extension MainTabView {
             switch store.selectedTab {
             case .pokit:
                 PokitRootView(store: store.scope(state: \.pokit, action: \.pokit))
-                    .pokitNavigationBar {
-                        pokitNavigationBar
-                    }
+                    .pokitNavigationBar { pokitNavigationBar }
                     .toolbarBackground(.hidden, for: .tabBar)
                 
             case .remind:
                 RemindView(store: store.scope(state: \.remind, action: \.remind))
-                    .pokitNavigationBar {
-                        remindNavigationBar
-                    }
+                    .pokitNavigationBar { remindNavigationBar }
                     .toolbarBackground(.hidden, for: .tabBar)
             }
         }

--- a/Projects/App/Sources/MainTab/MainTabFeatureView.swift
+++ b/Projects/App/Sources/MainTab/MainTabFeatureView.swift
@@ -135,24 +135,18 @@ private extension MainTabView {
         TabView(selection: $store.selectedTab) {
             switch store.selectedTab {
             case .pokit:
-                VStack(spacing: 0) {
-                    pokitNavigationBar
-                    
-                    PokitRootView(store: store.scope(state: \.pokit, action: \.pokit))
-                }
-                .toolbarBackground(.hidden, for: .tabBar)
-                .background(.pokit(.bg(.base)))
-                .navigationBarBackButtonHidden(true)
+                PokitRootView(store: store.scope(state: \.pokit, action: \.pokit))
+                    .pokitNavigationBar {
+                        pokitNavigationBar
+                    }
+                    .toolbarBackground(.hidden, for: .tabBar)
                 
             case .remind:
-                VStack(spacing: 0) {
-                    remindNavigationBar
-                    
-                    RemindView(store: store.scope(state: \.remind, action: \.remind))
-                }
-                .toolbarBackground(.hidden, for: .tabBar)
-                .background(.pokit(.bg(.base)))
-                .navigationBarBackButtonHidden(true)
+                RemindView(store: store.scope(state: \.remind, action: \.remind))
+                    .pokitNavigationBar {
+                        remindNavigationBar
+                    }
+                    .toolbarBackground(.hidden, for: .tabBar)
             }
         }
     }

--- a/Projects/App/Sources/MainTab/MainTabFeatureView.swift
+++ b/Projects/App/Sources/MainTab/MainTabFeatureView.swift
@@ -128,8 +128,6 @@ private extension MainTabView {
             ) { store in
                 ContentDetailView(store: store)
             }
-            .pokitNavigationBar(title: "")
-            .toolbar { navigationBar }
             .task { await send(.onAppear).finish() }
     }
 
@@ -137,26 +135,38 @@ private extension MainTabView {
         TabView(selection: $store.selectedTab) {
             switch store.selectedTab {
             case .pokit:
-                PokitRootView(store: store.scope(state: \.pokit, action: \.pokit))
-                    .toolbarBackground(.hidden, for: .tabBar)
+                VStack(spacing: 0) {
+                    pokitNavigationBar
+                    
+                    PokitRootView(store: store.scope(state: \.pokit, action: \.pokit))
+                }
+                .toolbarBackground(.hidden, for: .tabBar)
+                .background(.pokit(.bg(.base)))
+                .navigationBarBackButtonHidden(true)
+                
             case .remind:
-                RemindView(store: store.scope(state: \.remind, action: \.remind))
-                    .toolbarBackground(.hidden, for: .tabBar)
+                VStack(spacing: 0) {
+                    remindNavigationBar
+                    
+                    RemindView(store: store.scope(state: \.remind, action: \.remind))
+                }
+                .toolbarBackground(.hidden, for: .tabBar)
+                .background(.pokit(.bg(.base)))
+                .navigationBarBackButtonHidden(true)
             }
         }
     }
 
-    @ToolbarContentBuilder
-    var pokitNavigationBar: some ToolbarContent {
-        ToolbarItem(placement: .topBarLeading) {
-            Image(.logo(.pokit))
-                .resizable()
-                .frame(width: 104, height: 32)
-                .foregroundStyle(.pokit(.icon(.brand)))
-        }
-
-        ToolbarItem(placement: .topBarTrailing) {
-            HStack(spacing: 12) {
+    var pokitNavigationBar: some View {
+        PokitHeader {
+            PokitHeaderItems(placement: .leading) {
+                Image(.logo(.pokit))
+                    .resizable()
+                    .frame(width: 104, height: 32)
+                    .foregroundStyle(.pokit(.icon(.brand)))
+            }
+            
+            PokitHeaderItems(placement: .trailing) {
                 PokitToolbarButton(
                     .icon(.search),
                     action: { store.send(.pokit(.view(.searchButtonTapped))) }
@@ -171,38 +181,29 @@ private extension MainTabView {
                 )
             }
         }
+        .padding(.vertical, 8)
     }
 
-    @ToolbarContentBuilder
-    var remindNavigationBar: some ToolbarContent {
-        ToolbarItem(placement: .navigationBarLeading) {
-            Text("Remind")
-                .font(.system(size: 32, weight: .heavy))
-                .foregroundStyle(.pokit(.text(.brand)))
+    var remindNavigationBar: some View {
+        PokitHeader {
+            PokitHeaderItems(placement: .leading) {
+                Text("Remind")
+                    .font(.system(size: 32, weight: .heavy))
+                    .foregroundStyle(.pokit(.text(.brand)))
+            }
+            
+            PokitHeaderItems(placement: .trailing) {
+                PokitToolbarButton(
+                    .icon(.search),
+                    action: { store.send(.remind(.view(.searchButtonTapped))) }
+                )
+                PokitToolbarButton(
+                    .icon(.bell),
+                    action: { store.send(.remind(.view(.bellButtonTapped))) }
+                )
+            }
         }
-
-        ToolbarItem(placement: .navigationBarTrailing) {
-            PokitToolbarButton(
-                .icon(.search),
-                action: { store.send(.remind(.view(.searchButtonTapped))) }
-            )
-        }
-
-        ToolbarItem(placement: .navigationBarTrailing) {
-            PokitToolbarButton(
-                .icon(.bell),
-                action: { store.send(.remind(.view(.bellButtonTapped))) }
-            )
-        }
-
-    }
-
-    @ToolbarContentBuilder
-    var navigationBar: some ToolbarContent {
-        switch store.selectedTab {
-        case .pokit:  pokitNavigationBar
-        case .remind: remindNavigationBar
-        }
+        .padding(.vertical, 8)
     }
 
     var bottomTabBar: some View {

--- a/Projects/DSKit/Sources/Components/PokitHeader.swift
+++ b/Projects/DSKit/Sources/Components/PokitHeader.swift
@@ -8,12 +8,16 @@
 import SwiftUI
 
 public struct PokitHeader<Content: View>: View {
+    private let title: String?
+    
     @ViewBuilder
     private var toolBarItems: Content
     
     public init(
+        title: String? = nil,
         @ViewBuilder toolBarItems: () -> Content
     ) {
+        self.title = title
         self.toolBarItems = toolBarItems()
     }
     
@@ -24,6 +28,13 @@ public struct PokitHeader<Content: View>: View {
         .padding(.horizontal, 20)
         .padding(.vertical, 12)
         .background(.pokit(.bg(.base)))
+        .overlay {
+            if let title {
+                Text(title)
+                    .pokitFont(.title3)
+                    .foregroundStyle(.pokit(.text(.primary)))
+            }
+        }
     }
 }
 

--- a/Projects/DSKit/Sources/Components/PokitHeader.swift
+++ b/Projects/DSKit/Sources/Components/PokitHeader.swift
@@ -1,0 +1,52 @@
+//
+//  PokitHeader.swift
+//  DSKit
+//
+//  Created by 김도형 on 8/20/24.
+//
+
+import SwiftUI
+
+public struct PokitHeader<Content: View>: View {
+    @ViewBuilder
+    private var toolBarItems: Content
+    
+    public init(
+        @ViewBuilder toolBarItems: () -> Content
+    ) {
+        self.toolBarItems = toolBarItems()
+    }
+    
+    public var body: some View {
+        HStack {
+            toolBarItems
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 12)
+        .background(.pokit(.bg(.base)))
+    }
+}
+
+public extension PokitHeader {
+    enum HeaderType {
+        case pokit
+        case remind
+    }
+}
+
+#Preview {
+    PokitHeader {
+        PokitHeaderItems(placement: .leading) {
+            Image(.logo(.pokit))
+                .resizable()
+                .frame(width: 104, height: 32)
+                .foregroundStyle(.pokit(.icon(.brand)))
+        }
+        
+        PokitHeaderItems(placement: .trailing) {
+            PokitToolbarButton(.icon(.search), action: {})
+            PokitToolbarButton(.icon(.bell), action: {})
+            PokitToolbarButton(.icon(.setup), action: {})
+        }
+    }
+}

--- a/Projects/DSKit/Sources/Components/PokitHeaderItems.swift
+++ b/Projects/DSKit/Sources/Components/PokitHeaderItems.swift
@@ -1,0 +1,58 @@
+//
+//  PokitHeaderItems.swift
+//  DSKit
+//
+//  Created by 김도형 on 8/20/24.
+//
+
+import SwiftUI
+
+public struct PokitHeaderItems<Content: View>: View {
+    private let placement: Self.Placement
+    
+    @ViewBuilder
+    private var items: Content
+    
+    public init(
+        placement: Placement,
+        @ViewBuilder items: () -> Content
+    ) {
+        self.placement = placement
+        self.items = items()
+    }
+    
+    public var body: some View {
+        HStack(spacing: 12) {
+            switch placement {
+            case .leading:
+                items
+                
+                Spacer()
+            case .center:
+                Spacer()
+                
+                items
+                
+                Spacer()
+            case .trailing:
+                Spacer()
+                
+                items
+            }
+        }
+    }
+}
+
+public extension PokitHeaderItems {
+    enum Placement {
+        case leading
+        case center
+        case trailing
+    }
+}
+
+#Preview {
+    PokitHeaderItems(placement: .trailing) {
+        
+    }
+}

--- a/Projects/DSKit/Sources/Modifiers/PokitNavigationBarModifier.swift
+++ b/Projects/DSKit/Sources/Modifiers/PokitNavigationBarModifier.swift
@@ -7,24 +7,28 @@
 
 import SwiftUI
 
-struct PokitNavigationBarModifier: ViewModifier {
-    private let title: String
+struct PokitNavigationBarModifier<Header: View>: ViewModifier {
+    @ViewBuilder
+    private var header: Header
     
-    init(title: String) {
-        self.title = title
+    init(@ViewBuilder header: () -> Header) {
+        self.header = header()
     }
     
     func body(content: Content) -> some View {
-        content
-            .navigationTitle(title)
-            .navigationBarTitleDisplayMode(.inline)
-            .navigationBarBackButtonHidden()
+        VStack(spacing: 0) {
+            header
+            
+            content
+        }
+        .navigationBarBackButtonHidden()
+        .background(.pokit(.bg(.base)))
     }
 }
 
 
 public extension View {
-    func pokitNavigationBar(title: String) -> some View {
-        modifier(PokitNavigationBarModifier(title: title))
+    func pokitNavigationBar<Header: View>(@ViewBuilder header: () -> Header) -> some View {
+        modifier(PokitNavigationBarModifier(header: header))
     }
 }

--- a/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailView.swift
+++ b/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailView.swift
@@ -26,18 +26,16 @@ public struct CategoryDetailView: View {
 public extension CategoryDetailView {
     var body: some View {
         WithPerceptionTracking {
-            VStack(spacing: 0) {
-                navigationBar
-                
-                VStack(spacing: 16) {
-                    header
-                    contentScrollView
-                }
-                .padding(.horizontal, 20)
-                .padding(.top, 12)
+            VStack(spacing: 16) {
+                header
+                contentScrollView
             }
-            .navigationBarBackButtonHidden()
-            .background(.pokit(.bg(.base)))
+            .padding(.horizontal, 20)
+            .padding(.top, 12)
+            .pokitNavigationBar {
+                navigationBar
+            }
+            .ignoresSafeArea(edges: .bottom)
             .sheet(isPresented: $store.isCategorySheetPresented) {
                 PokitBottomSheet(
                     items: [.share, .edit, .delete],

--- a/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailView.swift
+++ b/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailView.swift
@@ -26,15 +26,18 @@ public struct CategoryDetailView: View {
 public extension CategoryDetailView {
     var body: some View {
         WithPerceptionTracking {
-            VStack(spacing: 16) {
-                header
-                contentScrollView
+            VStack(spacing: 0) {
+                navigationBar
+                
+                VStack(spacing: 16) {
+                    header
+                    contentScrollView
+                }
+                .padding(.horizontal, 20)
+                .padding(.top, 12)
             }
-            .padding(.top, 12)
-            .padding(.horizontal, 20)
-            .background(.pokit(.bg(.base)))
             .navigationBarBackButtonHidden()
-            .toolbar { self.navigationBar }
+            .background(.pokit(.bg(.base)))
             .sheet(isPresented: $store.isCategorySheetPresented) {
                 PokitBottomSheet(
                     items: [.share, .edit, .delete],
@@ -75,18 +78,19 @@ public extension CategoryDetailView {
 }
 //MARK: - Configure View
 private extension CategoryDetailView {
-    @ToolbarContentBuilder
-    var navigationBar: some ToolbarContent {
-        ToolbarItem(placement: .topBarLeading) {
-            PokitToolbarButton(
-                .icon(.arrowLeft),
-                action: { send(.dismiss) }
-            )
+    var navigationBar: some View {
+        PokitHeader {
+            PokitHeaderItems(placement: .leading) {
+                PokitToolbarButton(
+                    .icon(.arrowLeft),
+                    action: { send(.dismiss) }
+                )
+            }
+            PokitHeaderItems(placement: .trailing) {
+                PokitToolbarButton(.icon(.kebab), action: { send(.categoryKebobButtonTapped(.포킷삭제, selectedItem: nil)) })
+            }
         }
-        
-        ToolbarItem(placement: .topBarTrailing) {
-            PokitToolbarButton(.icon(.kebab), action: { send(.categoryKebobButtonTapped(.포킷삭제, selectedItem: nil)) })
-        }
+        .padding(.top, 8)
     }
     
     var header: some View {

--- a/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailView.swift
+++ b/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailView.swift
@@ -32,9 +32,7 @@ public extension CategoryDetailView {
             }
             .padding(.horizontal, 20)
             .padding(.top, 12)
-            .pokitNavigationBar {
-                navigationBar
-            }
+            .pokitNavigationBar { navigationBar }
             .ignoresSafeArea(edges: .bottom)
             .sheet(isPresented: $store.isCategorySheetPresented) {
                 PokitBottomSheet(

--- a/Projects/Feature/FeatureCategorySetting/Sources/PokitCategorySettingView.swift
+++ b/Projects/Feature/FeatureCategorySetting/Sources/PokitCategorySettingView.swift
@@ -28,17 +28,20 @@ public extension PokitCategorySettingView {
     var body: some View {
         WithPerceptionTracking {
             VStack(spacing: 0) {
-                thumbnailSection
-                pokitNameSection
-                myPokitSection
-                saveButton
+                navigationBar
+                
+                VStack(spacing: 0) {
+                    thumbnailSection
+                    pokitNameSection
+                    myPokitSection
+                    saveButton
+                }
+                .padding(.horizontal, 20)
+                .padding(.top, 16)
             }
-            .padding(.horizontal, 20)
             .background(.pokit(.bg(.base)))
-            .ignoresSafeArea(edges: .bottom)
             .navigationBarBackButtonHidden()
-            .toolbar { navigationBar }
-            .pokitNavigationBar(title: store.type.title)
+            .ignoresSafeArea(edges: .bottom)
             .sheet(isPresented: $store.isProfileSheetPresented) {
                 ProfileBottomSheet(
                     selectedImage: store.selectedProfile,
@@ -52,13 +55,15 @@ public extension PokitCategorySettingView {
 }
 //MARK: - Configure View
 private extension PokitCategorySettingView {
-    var navigationBar: some ToolbarContent {
-        ToolbarItem(placement: .topBarLeading) {
-            PokitToolbarButton(
-                .icon(.arrowLeft),
-                action: { send(.dismiss) }
-            )
+    var navigationBar: some View {
+        PokitHeader(title: store.type.title) {
+            PokitHeaderItems(placement: .leading) {
+                PokitToolbarButton(.icon(.arrowLeft)) {
+                    send(.dismiss)
+                }
+            }
         }
+        .padding(.top, 8)
     }
     /// 썸네일이미지 +프로필 설정
     @MainActor

--- a/Projects/Feature/FeatureCategorySetting/Sources/PokitCategorySettingView.swift
+++ b/Projects/Feature/FeatureCategorySetting/Sources/PokitCategorySettingView.swift
@@ -35,9 +35,7 @@ public extension PokitCategorySettingView {
             }
             .padding(.horizontal, 20)
             .padding(.top, 16)
-            .pokitNavigationBar {
-                navigationBar
-            }
+            .pokitNavigationBar { navigationBar }
             .ignoresSafeArea(edges: .bottom)
             .sheet(isPresented: $store.isProfileSheetPresented) {
                 ProfileBottomSheet(

--- a/Projects/Feature/FeatureCategorySetting/Sources/PokitCategorySettingView.swift
+++ b/Projects/Feature/FeatureCategorySetting/Sources/PokitCategorySettingView.swift
@@ -28,19 +28,16 @@ public extension PokitCategorySettingView {
     var body: some View {
         WithPerceptionTracking {
             VStack(spacing: 0) {
-                navigationBar
-                
-                VStack(spacing: 0) {
-                    thumbnailSection
-                    pokitNameSection
-                    myPokitSection
-                    saveButton
-                }
-                .padding(.horizontal, 20)
-                .padding(.top, 16)
+                thumbnailSection
+                pokitNameSection
+                myPokitSection
+                saveButton
             }
-            .background(.pokit(.bg(.base)))
-            .navigationBarBackButtonHidden()
+            .padding(.horizontal, 20)
+            .padding(.top, 16)
+            .pokitNavigationBar {
+                navigationBar
+            }
             .ignoresSafeArea(edges: .bottom)
             .sheet(isPresented: $store.isProfileSheetPresented) {
                 ProfileBottomSheet(

--- a/Projects/Feature/FeatureContentList/Sources/ContentList/ContentListView.swift
+++ b/Projects/Feature/FeatureContentList/Sources/ContentList/ContentListView.swift
@@ -24,17 +24,20 @@ public struct ContentListView: View {
 public extension ContentListView {
     var body: some View {
         WithPerceptionTracking {
-            VStack(spacing: 16) {
-                listHeader
-                    .padding(.horizontal, 20)
+            VStack(spacing: 0) {
+                toolbar
                 
-                list
+                VStack(spacing: 16) {
+                    listHeader
+                        .padding(.horizontal, 20)
+                    
+                    list
+                }
+                .padding(.top, 12)
             }
-            .padding(.top, 12)
             .background(.pokit(.bg(.base)))
             .ignoresSafeArea(edges: .bottom)
-            .pokitNavigationBar(title: store.contentType.title)
-            .toolbar { toolbar }
+            .navigationBarBackButtonHidden()
             .sheet(item: $store.bottomSheetItem) { content in
                 PokitBottomSheet(
                     items: [.share, .edit, .delete],
@@ -114,13 +117,15 @@ private extension ContentListView {
         }
     }
     
-    @ToolbarContentBuilder
-    var toolbar: some ToolbarContent {
-        ToolbarItem(placement: .topBarLeading) {
-            PokitToolbarButton(.icon(.arrowLeft)) {
-                send(.backButtonTapped)
+    var toolbar: some View {
+        PokitHeader(title: store.contentType.title) {
+            PokitHeaderItems(placement: .leading) {
+                PokitToolbarButton(.icon(.arrowLeft)) {
+                    send(.backButtonTapped)
+                }
             }
         }
+        .padding(.top, 8)
     }
 }
 //MARK: - Preview

--- a/Projects/Feature/FeatureContentList/Sources/ContentList/ContentListView.swift
+++ b/Projects/Feature/FeatureContentList/Sources/ContentList/ContentListView.swift
@@ -24,20 +24,17 @@ public struct ContentListView: View {
 public extension ContentListView {
     var body: some View {
         WithPerceptionTracking {
-            VStack(spacing: 0) {
-                toolbar
+            VStack(spacing: 16) {
+                listHeader
+                    .padding(.horizontal, 20)
                 
-                VStack(spacing: 16) {
-                    listHeader
-                        .padding(.horizontal, 20)
-                    
-                    list
-                }
-                .padding(.top, 12)
+                list
             }
-            .background(.pokit(.bg(.base)))
+            .padding(.top, 12)
+            .pokitNavigationBar {
+                toolbar
+            }
             .ignoresSafeArea(edges: .bottom)
-            .navigationBarBackButtonHidden()
             .sheet(item: $store.bottomSheetItem) { content in
                 PokitBottomSheet(
                     items: [.share, .edit, .delete],

--- a/Projects/Feature/FeatureContentList/Sources/ContentList/ContentListView.swift
+++ b/Projects/Feature/FeatureContentList/Sources/ContentList/ContentListView.swift
@@ -31,9 +31,7 @@ public extension ContentListView {
                 list
             }
             .padding(.top, 12)
-            .pokitNavigationBar {
-                toolbar
-            }
+            .pokitNavigationBar { toolbar }
             .ignoresSafeArea(edges: .bottom)
             .sheet(item: $store.bottomSheetItem) { content in
                 PokitBottomSheet(

--- a/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingView.swift
+++ b/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingView.swift
@@ -28,56 +28,53 @@ public extension ContentSettingView {
     var body: some View {
         WithPerceptionTracking {
             VStack(spacing: 0) {
-                navigationBar
-                
-                VStack(spacing: 0) {
-                    if store.contentLoading {
-                        PokitLoading()
-                    } else {
-                        ScrollView {
-                            VStack(spacing: 24) {
+                if store.contentLoading {
+                    PokitLoading()
+                } else {
+                    ScrollView {
+                        VStack(spacing: 24) {
+                            
+                            linkTextField
+                            
+                            titleTextField
+                            
+                            HStack(alignment: .bottom, spacing: 8) {
+                                pokitSelectButton
                                 
-                                linkTextField
-                                
-                                titleTextField
-                                
-                                HStack(alignment: .bottom, spacing: 8) {
-                                    pokitSelectButton
-                                    
-                                    addPokitButton
-                                }
-                                
-                                memoTextArea
-                                
-                                remindSwitchRadio
+                                addPokitButton
                             }
-                            .padding(.horizontal, 20)
-                            .padding(.top, 16)
+                            
+                            memoTextArea
+                            
+                            remindSwitchRadio
                         }
-                        .overlay(alignment: .bottom) {
-                            if store.state.showPopup {
-                                PokitLinkPopup(
-                                    "최대 30개의 포킷을 생성할 수 있습니다. \n포킷을 삭제한 뒤에 추가해주세요.",
-                                    isPresented: $store.showPopup,
-                                    type: .text
-                                )
-                            }
+                        .padding(.horizontal, 20)
+                        .padding(.top, 16)
+                    }
+                    .overlay(alignment: .bottom) {
+                        if store.state.showPopup {
+                            PokitLinkPopup(
+                                "최대 30개의 포킷을 생성할 수 있습니다. \n포킷을 삭제한 뒤에 추가해주세요.",
+                                isPresented: $store.showPopup,
+                                type: .text
+                            )
                         }
                     }
-                    
-                    let isDisable = store.urlText.isEmpty || store.title.isEmpty
-                    
-                    PokitBottomButton(
-                        "저장하기",
-                        state: isDisable ? .disable : .filled(.primary),
-                        isLoading: $store.saveIsLoading,
-                        action: { send(.saveBottomButtonTapped) }
-                    )
-                    .padding(.horizontal, 20)
                 }
+                
+                let isDisable = store.urlText.isEmpty || store.title.isEmpty
+                
+                PokitBottomButton(
+                    "저장하기",
+                    state: isDisable ? .disable : .filled(.primary),
+                    isLoading: $store.saveIsLoading,
+                    action: { send(.saveBottomButtonTapped) }
+                )
+                .padding(.horizontal, 20)
             }
-            .background(.pokit(.bg(.base)))
-            .navigationBarBackButtonHidden()
+            .pokitNavigationBar {
+                navigationBar
+            }
             .ignoresSafeArea(edges: focusedType == nil ? .bottom : [])
             .onAppear { send(.contentSettingViewOnAppeared) }
         }

--- a/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingView.swift
+++ b/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingView.swift
@@ -28,64 +28,72 @@ public extension ContentSettingView {
     var body: some View {
         WithPerceptionTracking {
             VStack(spacing: 0) {
-                if store.contentLoading {
-                    PokitLoading()
-                } else {
-                    ScrollView {
-                        VStack(spacing: 24) {
-                            
-                            linkTextField
-                            
-                            titleTextField
-                            
-                            HStack(alignment: .bottom, spacing: 8) {
-                                pokitSelectButton
+                navigationBar
+                
+                VStack(spacing: 0) {
+                    if store.contentLoading {
+                        PokitLoading()
+                    } else {
+                        ScrollView {
+                            VStack(spacing: 24) {
                                 
-                                addPokitButton
+                                linkTextField
+                                
+                                titleTextField
+                                
+                                HStack(alignment: .bottom, spacing: 8) {
+                                    pokitSelectButton
+                                    
+                                    addPokitButton
+                                }
+                                
+                                memoTextArea
+                                
+                                remindSwitchRadio
                             }
-                            
-                            memoTextArea
-                            
-                            remindSwitchRadio
+                            .padding(.horizontal, 20)
+                            .padding(.top, 16)
                         }
-                        .padding(.horizontal, 20)
-                    }
-                    .overlay(alignment: .bottom) {
-                        if store.state.showPopup {
-                            PokitLinkPopup(
-                                "최대 30개의 포킷을 생성할 수 있습니다. \n포킷을 삭제한 뒤에 추가해주세요.",
-                                isPresented: $store.showPopup,
-                                type: .text
-                            )
+                        .overlay(alignment: .bottom) {
+                            if store.state.showPopup {
+                                PokitLinkPopup(
+                                    "최대 30개의 포킷을 생성할 수 있습니다. \n포킷을 삭제한 뒤에 추가해주세요.",
+                                    isPresented: $store.showPopup,
+                                    type: .text
+                                )
+                            }
                         }
                     }
+                    
+                    let isDisable = store.urlText.isEmpty || store.title.isEmpty
+                    
+                    PokitBottomButton(
+                        "저장하기",
+                        state: isDisable ? .disable : .filled(.primary),
+                        isLoading: $store.saveIsLoading,
+                        action: { send(.saveBottomButtonTapped) }
+                    )
+                    .padding(.horizontal, 20)
                 }
-                
-                let isDisable = store.urlText.isEmpty || store.title.isEmpty
-                
-                PokitBottomButton(
-                    "저장하기",
-                    state: isDisable ? .disable : .filled(.primary),
-                    isLoading: $store.saveIsLoading,
-                    action: { send(.saveBottomButtonTapped) }
-                )
-                .padding(.horizontal, 20)
             }
-            .padding(.top, 16)
             .background(.pokit(.bg(.base)))
+            .navigationBarBackButtonHidden()
             .ignoresSafeArea(edges: focusedType == nil ? .bottom : [])
-            .pokitNavigationBar(title: store.content == nil ? "링크 추가" : "링크 수정")
-            .toolbar { navigationBar }
             .onAppear { send(.contentSettingViewOnAppeared) }
         }
     }
 }
 //MARK: - Configure View
 private extension ContentSettingView {
-    var navigationBar: some ToolbarContent {
-        ToolbarItem(placement: .topBarLeading) {
-            PokitToolbarButton(.icon(.arrowLeft), action: { send(.dismiss) })
+    var navigationBar: some View {
+        PokitHeader(title: store.content == nil ? "링크 추가" : "링크 수정") {
+            PokitHeaderItems(placement: .leading) {
+                PokitToolbarButton(.icon(.arrowLeft)) {
+                    send(.dismiss)
+                }
+            }
         }
+        .padding(.top, 8)
     }
     var linkTextField: some View {
         VStack(spacing: 16) {

--- a/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingView.swift
+++ b/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingView.swift
@@ -72,9 +72,7 @@ public extension ContentSettingView {
                 )
                 .padding(.horizontal, 20)
             }
-            .pokitNavigationBar {
-                navigationBar
-            }
+            .pokitNavigationBar { navigationBar }
             .ignoresSafeArea(edges: focusedType == nil ? .bottom : [])
             .onAppear { send(.contentSettingViewOnAppeared) }
         }

--- a/Projects/Feature/FeatureLogin/Sources/AgreeToTerms/AgreeToTermsView.swift
+++ b/Projects/Feature/FeatureLogin/Sources/AgreeToTerms/AgreeToTermsView.swift
@@ -44,16 +44,16 @@ public extension AgreeToTermsView {
                 )
             }
             .padding(.horizontal, 20)
-            .background(.pokit(.bg(.base)))
-            .ignoresSafeArea(edges: .bottom)
-            .pokitNavigationBar(title: "")
-            .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
-                    PokitToolbarButton(.icon(.arrowLeft)) {
-                        send(.backButtonTapped)
+            .pokitNavigationBar {
+                PokitHeader {
+                    PokitHeaderItems(placement: .leading) {
+                        PokitToolbarButton(.icon(.arrowLeft)) {
+                            send(.backButtonTapped)
+                        }
                     }
                 }
             }
+            .ignoresSafeArea(edges: .bottom)
         }
     }
 }

--- a/Projects/Feature/FeatureLogin/Sources/LoginRoot/LoginRootView.swift
+++ b/Projects/Feature/FeatureLogin/Sources/LoginRoot/LoginRootView.swift
@@ -54,7 +54,7 @@ public extension LoginRootView {
                     .padding(.bottom, 36)
                     .background(.pokit(.bg(.base)))
                     .ignoresSafeArea(edges: .bottom)
-                    .pokitNavigationBar(title: "")
+                    .navigationBarBackButtonHidden()
                 }
             } destination: { path in
                 switch path.case {

--- a/Projects/Feature/FeatureLogin/Sources/RegisterNickname/RegisterNicknameView.swift
+++ b/Projects/Feature/FeatureLogin/Sources/RegisterNickname/RegisterNicknameView.swift
@@ -47,16 +47,16 @@ public extension RegisterNicknameView {
                 .setKeyboardHeight()
             }
             .padding(.horizontal, 20)
-            .background(.pokit(.bg(.base)))
-            .ignoresSafeArea(edges: .bottom)
-            .pokitNavigationBar(title: "")
-            .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
-                    PokitToolbarButton(.icon(.arrowLeft)) {
-                        send(.backButtonTapped)
+            .pokitNavigationBar {
+                PokitHeader {
+                    PokitHeaderItems(placement: .leading) {
+                        PokitToolbarButton(.icon(.arrowLeft)) {
+                            send(.backButtonTapped)
+                        }
                     }
                 }
             }
+            .ignoresSafeArea(edges: .bottom)
         }
     }
 }

--- a/Projects/Feature/FeatureLogin/Sources/SelectField/SelectFieldView.swift
+++ b/Projects/Feature/FeatureLogin/Sources/SelectField/SelectFieldView.swift
@@ -41,16 +41,16 @@ public extension SelectFieldView {
                 )
             }
             .padding(.horizontal, 20)
-            .background(.pokit(.bg(.base)))
-            .ignoresSafeArea(edges: .bottom)
-            .pokitNavigationBar(title: "")
-            .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
-                    PokitToolbarButton(.icon(.arrowLeft)) {
-                        send(.backButtonTapped)
+            .pokitNavigationBar {
+                PokitHeader {
+                    PokitHeaderItems(placement: .leading) {
+                        PokitToolbarButton(.icon(.arrowLeft)) {
+                            send(.backButtonTapped)
+                        }
                     }
                 }
             }
+            .ignoresSafeArea(edges: .bottom)
             .task { await send(.onAppear).finish() }
         }
     }

--- a/Projects/Feature/FeatureLogin/Sources/SignUpDone/SignUpDoneView.swift
+++ b/Projects/Feature/FeatureLogin/Sources/SignUpDone/SignUpDoneView.swift
@@ -45,16 +45,16 @@ public extension SignUpDoneView {
                 .padding(.horizontal, 20)
                 .background(.pokit(.bg(.base)))
             }
-            .background(.pokit(.bg(.base)))
-            .ignoresSafeArea(edges: .bottom)
-            .pokitNavigationBar(title: "")
-            .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
-                    PokitToolbarButton(.icon(.arrowLeft)) {
-                        send(.backButtonTapped)
+            .pokitNavigationBar {
+                PokitHeader {
+                    PokitHeaderItems(placement: .leading) {
+                        PokitToolbarButton(.icon(.arrowLeft)) {
+                            send(.backButtonTapped)
+                        }
                     }
                 }
             }
+            .ignoresSafeArea(edges: .bottom)
         }
     }
 }

--- a/Projects/Feature/FeaturePokit/Sources/PokitRootView.swift
+++ b/Projects/Feature/FeaturePokit/Sources/PokitRootView.swift
@@ -36,6 +36,7 @@ public extension PokitRootView {
             .padding(.vertical, 16)
             .background(.pokit(.bg(.base)))
             .ignoresSafeArea(edges: .bottom)
+            .navigationBarBackButtonHidden(true)
             .sheet(isPresented: $store.isKebobSheetPresented) {
                 PokitBottomSheet(
                     items: [.share, .edit, .delete],

--- a/Projects/Feature/FeatureRemind/Sources/Remind/RemindView.swift
+++ b/Projects/Feature/FeatureRemind/Sources/Remind/RemindView.swift
@@ -31,7 +31,7 @@ public extension RemindView {
             contents
                 .background(.pokit(.bg(.base)))
                 .ignoresSafeArea(edges: .bottom)
-                .pokitNavigationBar(title: "")
+                .navigationBarBackButtonHidden(true)
                 .sheet(item: $store.bottomSheetItem) { content in
                     PokitBottomSheet(
                         items: [.share, .edit, .delete],

--- a/Projects/Feature/FeatureSetting/Sources/Alert/PokitAlertBoxView.swift
+++ b/Projects/Feature/FeatureSetting/Sources/Alert/PokitAlertBoxView.swift
@@ -25,55 +25,59 @@ public struct PokitAlertBoxView: View {
 public extension PokitAlertBoxView {
     var body: some View {
         WithPerceptionTracking {
-            VStack(alignment: .leading, spacing: 0) {
-                if let alertContents = store.alertContents {
-                    if alertContents.isEmpty {
-                        VStack {
-                            PokitCaution(
-                                image: .pooki,
-                                titleKey: "알람이 없어요",
-                                message: "리마인드 알림을 설정하세요"
-                            )
-                            .padding(.top, 84)
-                            Spacer()
+            VStack(spacing: 0) {
+                navigationBar
+                
+                VStack(alignment: .leading, spacing: 0) {
+                    if let alertContents = store.alertContents {
+                        if alertContents.isEmpty {
+                            VStack {
+                                PokitCaution(
+                                    image: .pooki,
+                                    titleKey: "알람이 없어요",
+                                    message: "리마인드 알림을 설정하세요"
+                                )
+                                .padding(.top, 84)
+                                Spacer()
+                            }
+                        } else {
+                            List {
+                                ForEach(alertContents, id: \.id) { item in
+                                    Button(action: { send(.itemSelected(item: item)) }) {
+                                        AlertContent(item: item)
+                                    }
+                                    .listRowSeparator(.hidden)
+                                    .listRowInsets(EdgeInsets())
+                                    .onDelete(deleteAction: { delete(item) })
+                                }
+                                .listRowBackground(Color.pokit(.bg(.base)))
+                                .padding(.top, 16)
+                            }
+                            .listStyle(.plain)
                         }
                     } else {
-                        List {
-                            ForEach(alertContents, id: \.id) { item in
-                                Button(action: { send(.itemSelected(item: item)) }) {
-                                    AlertContent(item: item)
-                                }
-                                .listRowSeparator(.hidden)
-                                .listRowInsets(EdgeInsets())
-                                .onDelete(deleteAction: { delete(item) })
-                            }
-                            .listRowBackground(Color.pokit(.bg(.base)))
-                        }
-                        .listStyle(.plain)
+                        PokitLoading()
                     }
-                } else {
-                    PokitLoading()
                 }
             }
-            .padding(.top, 16)
             .background(.pokit(.bg(.base)))
             .ignoresSafeArea(edges: .bottom)
-            .pokitNavigationBar(title: "알림함")
-            .toolbar { navigationBar }
+            .navigationBarBackButtonHidden()
             .task { await send(.onAppear).finish() }
         }
     }
 }
 //MARK: - Configure View
 private extension PokitAlertBoxView {
-    @ToolbarContentBuilder
-    var navigationBar: some ToolbarContent {
-        ToolbarItem(placement: .topBarLeading) {
-            PokitToolbarButton(
-                .icon(.arrowLeft),
-                action: { send(.dismiss) }
-            )
+    var navigationBar: some View {
+        PokitHeader(title: "알림함") {
+            PokitHeaderItems(placement: .leading) {
+                PokitToolbarButton(.icon(.arrowLeft)) {
+                    send(.dismiss)
+                }
+            }
         }
+        .padding(.top, 8)
     }
     
     func delete(_ item: AlertItem) {

--- a/Projects/Feature/FeatureSetting/Sources/Alert/PokitAlertBoxView.swift
+++ b/Projects/Feature/FeatureSetting/Sources/Alert/PokitAlertBoxView.swift
@@ -56,9 +56,7 @@ public extension PokitAlertBoxView {
                     PokitLoading()
                 }
             }
-            .pokitNavigationBar {
-                navigationBar
-            }
+            .pokitNavigationBar { navigationBar }
             .ignoresSafeArea(edges: .bottom)
             .task { await send(.onAppear).finish() }
         }

--- a/Projects/Feature/FeatureSetting/Sources/Alert/PokitAlertBoxView.swift
+++ b/Projects/Feature/FeatureSetting/Sources/Alert/PokitAlertBoxView.swift
@@ -25,44 +25,41 @@ public struct PokitAlertBoxView: View {
 public extension PokitAlertBoxView {
     var body: some View {
         WithPerceptionTracking {
-            VStack(spacing: 0) {
-                navigationBar
-                
-                VStack(alignment: .leading, spacing: 0) {
-                    if let alertContents = store.alertContents {
-                        if alertContents.isEmpty {
-                            VStack {
-                                PokitCaution(
-                                    image: .pooki,
-                                    titleKey: "알람이 없어요",
-                                    message: "리마인드 알림을 설정하세요"
-                                )
-                                .padding(.top, 84)
-                                Spacer()
-                            }
-                        } else {
-                            List {
-                                ForEach(alertContents, id: \.id) { item in
-                                    Button(action: { send(.itemSelected(item: item)) }) {
-                                        AlertContent(item: item)
-                                    }
-                                    .listRowSeparator(.hidden)
-                                    .listRowInsets(EdgeInsets())
-                                    .onDelete(deleteAction: { delete(item) })
-                                }
-                                .listRowBackground(Color.pokit(.bg(.base)))
-                                .padding(.top, 16)
-                            }
-                            .listStyle(.plain)
+            VStack(alignment: .leading, spacing: 0) {
+                if let alertContents = store.alertContents {
+                    if alertContents.isEmpty {
+                        VStack {
+                            PokitCaution(
+                                image: .pooki,
+                                titleKey: "알람이 없어요",
+                                message: "리마인드 알림을 설정하세요"
+                            )
+                            .padding(.top, 84)
+                            Spacer()
                         }
                     } else {
-                        PokitLoading()
+                        List {
+                            ForEach(alertContents, id: \.id) { item in
+                                Button(action: { send(.itemSelected(item: item)) }) {
+                                    AlertContent(item: item)
+                                }
+                                .listRowSeparator(.hidden)
+                                .listRowInsets(EdgeInsets())
+                                .onDelete(deleteAction: { delete(item) })
+                            }
+                            .listRowBackground(Color.pokit(.bg(.base)))
+                            .padding(.top, 16)
+                        }
+                        .listStyle(.plain)
                     }
+                } else {
+                    PokitLoading()
                 }
             }
-            .background(.pokit(.bg(.base)))
+            .pokitNavigationBar {
+                navigationBar
+            }
             .ignoresSafeArea(edges: .bottom)
-            .navigationBarBackButtonHidden()
             .task { await send(.onAppear).finish() }
         }
     }

--- a/Projects/Feature/FeatureSetting/Sources/Setting/NickNameSetting/NickNameSettingView.swift
+++ b/Projects/Feature/FeatureSetting/Sources/Setting/NickNameSetting/NickNameSettingView.swift
@@ -26,43 +26,47 @@ public extension NickNameSettingView {
     var body: some View {
         WithPerceptionTracking {
             VStack(spacing: 0) {
-                PokitTextInput(
-                    text: $store.text,
-                    state: $store.textfieldState,
-                    info: "한글, 영어, 숫자로만 입력이 가능합니다.",
-                    maxLetter: 10,
-                    focusState: $isFocused,
-                    equals: true
-                )
-                Spacer()
+                navigationBar
+                
+                VStack(spacing: 0) {
+                    PokitTextInput(
+                        text: $store.text,
+                        state: $store.textfieldState,
+                        info: "한글, 영어, 숫자로만 입력이 가능합니다.",
+                        maxLetter: 10,
+                        focusState: $isFocused,
+                        equals: true
+                    )
+                    Spacer()
+                }
+                .overlay(alignment: .bottom) {
+                    PokitBottomButton(
+                        "저장",
+                        state: store.buttonState,
+                        action: { send(.saveButtonTapped) }
+                    )
+                    .setKeyboardHeight()
+                }
+                .padding(.horizontal, 20)
+                .padding(.top, 16)
             }
-            .overlay(alignment: .bottom) {
-                PokitBottomButton(
-                    "저장",
-                    state: store.buttonState,
-                    action: { send(.saveButtonTapped) }
-                )
-                .setKeyboardHeight()
-            }
-            .padding(.top, 16)
-            .padding(.horizontal, 20)
             .background(.pokit(.bg(.base)))
             .ignoresSafeArea(edges: .bottom)
             .navigationBarBackButtonHidden()
-            .pokitNavigationBar(title: "닉네임 설정")
-            .toolbar { navigationBar }
         }
     }
 }
 //MARK: - Configure View
 private extension NickNameSettingView {
-    var navigationBar: some ToolbarContent {
-        ToolbarItem(placement: .topBarLeading) {
-            PokitToolbarButton(
-                .icon(.arrowLeft),
-                action: { send(.dismiss) }
-            )
+    var navigationBar: some View {
+        PokitHeader(title: "닉네임 설정") {
+            PokitHeaderItems(placement: .leading) {
+                PokitToolbarButton(.icon(.arrowLeft)) {
+                    send(.dismiss)
+                }
+            }
         }
+        .padding(.top, 8)
     }
     
 }

--- a/Projects/Feature/FeatureSetting/Sources/Setting/NickNameSetting/NickNameSettingView.swift
+++ b/Projects/Feature/FeatureSetting/Sources/Setting/NickNameSetting/NickNameSettingView.swift
@@ -26,33 +26,30 @@ public extension NickNameSettingView {
     var body: some View {
         WithPerceptionTracking {
             VStack(spacing: 0) {
-                navigationBar
-                
-                VStack(spacing: 0) {
-                    PokitTextInput(
-                        text: $store.text,
-                        state: $store.textfieldState,
-                        info: "한글, 영어, 숫자로만 입력이 가능합니다.",
-                        maxLetter: 10,
-                        focusState: $isFocused,
-                        equals: true
-                    )
-                    Spacer()
-                }
-                .overlay(alignment: .bottom) {
-                    PokitBottomButton(
-                        "저장",
-                        state: store.buttonState,
-                        action: { send(.saveButtonTapped) }
-                    )
-                    .setKeyboardHeight()
-                }
-                .padding(.horizontal, 20)
-                .padding(.top, 16)
+                PokitTextInput(
+                    text: $store.text,
+                    state: $store.textfieldState,
+                    info: "한글, 영어, 숫자로만 입력이 가능합니다.",
+                    maxLetter: 10,
+                    focusState: $isFocused,
+                    equals: true
+                )
+                Spacer()
             }
-            .background(.pokit(.bg(.base)))
+            .overlay(alignment: .bottom) {
+                PokitBottomButton(
+                    "저장",
+                    state: store.buttonState,
+                    action: { send(.saveButtonTapped) }
+                )
+                .setKeyboardHeight()
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 16)
+            .pokitNavigationBar {
+                navigationBar
+            }
             .ignoresSafeArea(edges: .bottom)
-            .navigationBarBackButtonHidden()
         }
     }
 }

--- a/Projects/Feature/FeatureSetting/Sources/Setting/NickNameSetting/NickNameSettingView.swift
+++ b/Projects/Feature/FeatureSetting/Sources/Setting/NickNameSetting/NickNameSettingView.swift
@@ -46,9 +46,7 @@ public extension NickNameSettingView {
             }
             .padding(.horizontal, 20)
             .padding(.top, 16)
-            .pokitNavigationBar {
-                navigationBar
-            }
+            .pokitNavigationBar { navigationBar }
             .ignoresSafeArea(edges: .bottom)
         }
     }

--- a/Projects/Feature/FeatureSetting/Sources/Setting/PokitSettingView.swift
+++ b/Projects/Feature/FeatureSetting/Sources/Setting/PokitSettingView.swift
@@ -25,17 +25,18 @@ public extension PokitSettingView {
     var body: some View {
         WithPerceptionTracking {
             VStack(spacing: 0) {
-                section1
-                section2
-                section3
-                Spacer()
+                navigationBar
+                VStack(spacing: 0) {
+                    section1
+                    section2
+                    section3
+                    Spacer()
+                }
+                .padding(.top, 16)
             }
-            .padding(.top, 16)
             .background(.pokit(.bg(.base)))
             .ignoresSafeArea(edges: .bottom)
             .navigationBarBackButtonHidden()
-            .pokitNavigationBar(title: "설정")
-            .toolbar { navigationBar }
             .sheet(isPresented: $store.isLogoutPresented) {
                 PokitAlert(
                     "로그아웃 하시겠습니까?",
@@ -123,14 +124,15 @@ private extension PokitSettingView {
         }
     }
     
-    @ToolbarContentBuilder
-    var navigationBar: some ToolbarContent {
-        ToolbarItem(placement: .topBarLeading) {
-            PokitToolbarButton(
-                .icon(.arrowLeft), 
-                action: { send(.dismiss) }
-            )
+    var navigationBar: some View {
+        PokitHeader(title: "설정") {
+            PokitHeaderItems(placement: .leading) {
+                PokitToolbarButton(.icon(.arrowLeft)) {
+                    send(.dismiss)
+                }
+            }
         }
+        .padding(.top, 8)
     }
     
     struct SettingItem: View {

--- a/Projects/Feature/FeatureSetting/Sources/Setting/PokitSettingView.swift
+++ b/Projects/Feature/FeatureSetting/Sources/Setting/PokitSettingView.swift
@@ -24,19 +24,18 @@ public struct PokitSettingView: View {
 public extension PokitSettingView {
     var body: some View {
         WithPerceptionTracking {
+            navigationBar
             VStack(spacing: 0) {
-                navigationBar
-                VStack(spacing: 0) {
-                    section1
-                    section2
-                    section3
-                    Spacer()
-                }
-                .padding(.top, 16)
+                section1
+                section2
+                section3
+                Spacer()
             }
-            .background(.pokit(.bg(.base)))
+            .padding(.top, 16)
+            .pokitNavigationBar {
+                navigationBar
+            }
             .ignoresSafeArea(edges: .bottom)
-            .navigationBarBackButtonHidden()
             .sheet(isPresented: $store.isLogoutPresented) {
                 PokitAlert(
                     "로그아웃 하시겠습니까?",

--- a/Projects/Feature/FeatureSetting/Sources/Setting/PokitSettingView.swift
+++ b/Projects/Feature/FeatureSetting/Sources/Setting/PokitSettingView.swift
@@ -24,7 +24,6 @@ public struct PokitSettingView: View {
 public extension PokitSettingView {
     var body: some View {
         WithPerceptionTracking {
-            navigationBar
             VStack(spacing: 0) {
                 section1
                 section2
@@ -32,9 +31,7 @@ public extension PokitSettingView {
                 Spacer()
             }
             .padding(.top, 16)
-            .pokitNavigationBar {
-                navigationBar
-            }
+            .pokitNavigationBar { navigationBar }
             .ignoresSafeArea(edges: .bottom)
             .sheet(isPresented: $store.isLogoutPresented) {
                 PokitAlert(


### PR DESCRIPTION
## #️⃣연관된 이슈

> #92 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 디자이너 요청에 따라 커스텀 네비게이션 바로 전환했습니다. (죄송합니다..ㅎㅎ)
- `PokitHeader`, `PokitHeaderItems`를 추가하였습니다.
- `.navigationBar`모디파이어를 새롭게 바꿨습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
- 사용방법
```swift
...
.pokitNavigationBar {
    PokitHeader {
        PokitHeaderItems(placement: .leading) {
            PokitToolbarButton(.icon(.arrowLeft)) {
                send(.backButtonTapped)
            }
        }
    }
}
...
```
- 내부적으로 `VStack`으로 구현되었기 때문에 해당하는 화면의 최상단에 써야합니다!
```swift
...
func body(content: Content) -> some View {
    VStack(spacing: 0) {
        header
        
        content
    }
    .navigationBarBackButtonHidden()
    .background(.pokit(.bg(.base)))
}
...
```

close 이슈번호
