### PR TITLE
fix: 최신순 정렬 수정

### DIFF
--- a/Projects/Domain/Sources/Base/BaseCategoryItem.swift
+++ b/Projects/Domain/Sources/Base/BaseCategoryItem.swift
@@ -9,7 +9,7 @@ import Foundation
 
 import Util
 
-public struct BaseCategoryItem: Identifiable, Equatable, PokitSelectItem, PokitCardItem {
+public struct BaseCategoryItem: Identifiable, Equatable, PokitSelectItem, PokitCardItem, Sortable {
     public let id: Int
     public let userId: Int
     public let categoryName: String

--- a/Projects/Domain/Sources/Base/BaseCategoryListInquiry.swift
+++ b/Projects/Domain/Sources/Base/BaseCategoryListInquiry.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 
+import Util
+
 public struct BaseCategoryListInquiry: Equatable {
     public var data: [BaseCategoryItem]?
     public var page: Int

--- a/Projects/Domain/Sources/Base/BaseContentItem.swift
+++ b/Projects/Domain/Sources/Base/BaseContentItem.swift
@@ -9,7 +9,7 @@ import Foundation
 
 import Util
 
-public struct BaseContentItem: Identifiable, Equatable, PokitLinkCardItem {
+public struct BaseContentItem: Identifiable, Equatable, PokitLinkCardItem, Sortable {
     public let id: Int
     public let categoryName: String
     public let categoryId: Int

--- a/Projects/Feature/FeaturePokit/Sources/PokitRootFeature.swift
+++ b/Projects/Feature/FeaturePokit/Sources/PokitRootFeature.swift
@@ -276,10 +276,11 @@ private extension PokitRootFeature {
                 
             case .sort(.최신순):
                 /// `포킷`의 최신순 정렬일 때
-                state.folderType == .folder(.포킷)
-                // - TODO: 정렬 조회 필요
-                ? state.domain.categoryList.data?.sort { $0.createdAt < $1.createdAt }
-                : state.domain.unclassifiedContentList.data?.sort { $0.createdAt < $1.createdAt }
+                if state.folderType == .folder(.포킷) {
+                    state.domain.categoryList.data?.sortByDate()
+                } else {
+                    state.domain.unclassifiedContentList.data?.sortByDate()
+                }
             default: return .none
             }
             return .none

--- a/Projects/Util/Sources/Extension/Array+Sortable.swift
+++ b/Projects/Util/Sources/Extension/Array+Sortable.swift
@@ -1,0 +1,19 @@
+//
+//  Array+Sortable.swift
+//  Util
+//
+//  Created by 김민호 on 8/22/24.
+//
+
+import Foundation
+
+extension Array where Element: Sortable {
+    /// createdAt을 이용해 최신순 정렬을 도와주는 함수
+    public mutating func sortByDate(dateFormat: DateFormat = .yearMonthDate) {
+        return self.sort { first, second in
+            guard let firstDate = dateFormat.formatter.date(from: first.createdAt),
+                  let secondDate = dateFormat.formatter.date(from: second.createdAt) else { return false }
+            return firstDate > secondDate
+        }
+    }
+}

--- a/Projects/Util/Sources/Extension/DateFormat.swift
+++ b/Projects/Util/Sources/Extension/DateFormat.swift
@@ -1,0 +1,39 @@
+//
+//  Date+formatter.swift
+//  Util
+//
+//  Created by 김민호 on 8/22/24.
+//
+
+import Foundation
+
+public enum DateFormat: String {
+    /// 포맷형식: yyyy-MM-dd
+    case yearMonthDate = "yyyy.MM.dd"
+}
+
+extension DateFormat {
+    public var formatter: DateFormatter {
+        guard let fmt = DateFormat.cachedFormatters[self] else {
+            let generatedFormatter = DateFormat.makeFormatter(withDateFormat: self)
+            DateFormat.cachedFormatters[self] = generatedFormatter
+            return generatedFormatter
+        }
+        return fmt
+    }
+    
+    private static var cachedFormatters: [DateFormat: DateFormatter] = [:]
+    
+    private static func makeFormatter(withDateFormat dateFormat: DateFormat) -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.dateFormat = dateFormat.rawValue
+        formatter.locale = .current
+        return formatter
+    }
+}
+
+extension Date {
+    func formattedString(dateFormat: DateFormat) -> String {
+        return dateFormat.formatter.string(from: self)
+    }
+}

--- a/Projects/Util/Sources/Protocols/Sortable.swift
+++ b/Projects/Util/Sources/Protocols/Sortable.swift
@@ -1,0 +1,13 @@
+//
+//  Sortable.swift
+//  Util
+//
+//  Created by 김민호 on 8/22/24.
+//
+
+import Foundation
+
+public protocol Sortable {
+    var createdAt: String { get }
+}
+


### PR DESCRIPTION
## #️⃣연관된 이슈
#92

## 📝작업 내용
- 정렬이 적용이 안되던 버그를 수정

기존의 정렬은 createdAt이라는 String값을 서버로부터 받아와 이를 토대로 정렬을 돌렸었는데, 
정렬이 되는것처럼 보여도 프린트 찍어서 확인해보니 순서가 엉망이였습니다.
```swift
/// 카테고리 일 때
state.domain.categoryList.data?.sort { $0.createdAt < $1.createdAt }
/// 미분류 카테고리 일 때
state.domain.unclassifiedContentList.data?.sort { $0.createdAt < $1.createdAt }
```
이는 String값만으로 sort를 진행하기 때문에 정확도가 많이 떨어지는 방식이였습니다.
String값을 Date로 변환하고 이를 근거로 정렬을 수행하고자 하였습니다.

DateFormatter를 생성하는 것은 생각보다 비용이 많이 드는 작업에 속합니다. 
그렇기 때문에 이곳저곳에서 인스턴스를 만들고 버리는 것 보다는 단일 인스턴스를 캐시화 하는 것이 효율적입니다.

```swift
public enum DateFormat: String {
    /// 포맷형식: yyyy-MM-dd
    case yearMonthDate = "yyyy.MM.dd"
}

extension DateFormat {
    public var formatter: DateFormatter {
        guard let fmt = DateFormat.cachedFormatters[self] else {
            let generatedFormatter = DateFormat.makeFormatter(withDateFormat: self)
            DateFormat.cachedFormatters[self] = generatedFormatter
            return generatedFormatter
        }
        return fmt
    }
    
    private static var cachedFormatters: [DateFormat: DateFormatter] = [:]
    
    private static func makeFormatter(withDateFormat dateFormat: DateFormat) -> DateFormatter {
        let formatter = DateFormatter()
        formatter.dateFormat = dateFormat.rawValue
        formatter.locale = .current
        return formatter
    }
}
```
이렇게 만들어둔 포맷형식을 활용한다면 비용을 실제로 줄일 수 있습니다.

이후 Sortable이라는 프로토콜을 하나 만들어줍니다. 최신순 정렬이 필요한 구조체에 채택할 수 있습니다.
```swift
public protocol Sortable {
    var createdAt: String { get }
}
```
Array를 extension하고 정렬함수를 만들어줍니다. 요소는 당연하게도 Sortable을 채택해야 합니다.
매개변수로는 아까 만둔 포매터가 들어갑니다.
```swift
extension Array where Element: Sortable {
    /// createdAt을 이용해 최신순 정렬을 도와주는 함수
    public mutating func sortByDate(dateFormat: DateFormat = .yearMonthDate) {
        return self.sort { first, second in
            guard let firstDate = dateFormat.formatter.date(from: first.createdAt),
                  let secondDate = dateFormat.formatter.date(from: second.createdAt) else { return false }
            return firstDate > secondDate
        }
    }
}
```
따로 optional을 핸들링하는 과정은 필요없습니다.
```swift
 /// `포킷`의 최신순 정렬일 때
if state.folderType == .folder(.포킷) {
    state.domain.categoryList.data?.sortByDate()
} else {
    state.domain.unclassifiedContentList.data?.sortByDate()
}
```


포매터의 인스턴스를 생성하는 모든곳에서 제가 적용한 단일인스턴스만 사용하는 것을 목표로 수정하면 좋을 것 같습니다😏

이름순 정렬도 추후 작업해야할 것 같습니다
### 스크린샷 (선택)
|<img src="https://github.com/user-attachments/assets/7e4c956e-af55-4098-af07-322f77907313"></img>|
|:-:|
|`정렬 예시`|


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

close 이슈번호
