### PR TITLE
Fix: PM의 QA 반영

### DIFF
--- a/Projects/App/Sources/MainTab/MainTabPath.swift
+++ b/Projects/App/Sources/MainTab/MainTabPath.swift
@@ -152,6 +152,7 @@ public extension MainTabFeature {
             /// - 링크 추가하기
             case .delegate(.링크추가하기):
                 state.path.append(.링크추가및수정(ContentSettingFeature.State(urlText: state.link)))
+                state.link = nil
                 return .none
 
             /// - 링크추가 및 수정에서 저장하기 눌렀을 때

--- a/Projects/CoreKit/Sources/Data/DTO/Base/BaseUserResponse.swift
+++ b/Projects/CoreKit/Sources/Data/DTO/Base/BaseUserResponse.swift
@@ -8,9 +8,9 @@
 import Foundation
 /// 닉네임 수정, 회원등록 API Response 공통
 public struct BaseUserResponse: Decodable {
-    let id: Int
-    let email: String
-    let nickname: String
+    public let id: Int
+    public let email: String
+    public let nickname: String
 }
 
 extension BaseUserResponse {

--- a/Projects/CoreKit/Sources/Data/DTO/Base/ContentBaseResponse.swift
+++ b/Projects/CoreKit/Sources/Data/DTO/Base/ContentBaseResponse.swift
@@ -15,7 +15,7 @@ public struct ContentBaseResponse: Decodable {
     public let title: String
     public let thumbNail: String
     public let createdAt: String
-    public let isRead: Bool
+    public let isRead: Bool?
 }
 
 extension ContentBaseResponse {

--- a/Projects/CoreKit/Sources/Data/Network/Content/ContentClient.swift
+++ b/Projects/CoreKit/Sources/Data/Network/Content/ContentClient.swift
@@ -36,7 +36,7 @@ public struct ContentClient {
     ) async throws -> BookmarkResponse
     public var 즐겨찾기_취소: @Sendable (
         _ contentId: String
-    ) async throws -> EmptyResponse
+    ) async throws -> Void
     public var 카테고리_내_컨텐츠_목록_조회: @Sendable (
         _ contentId: String,
         _ pageable: BasePageableRequest,
@@ -72,7 +72,7 @@ extension ContentClient: DependencyKey {
                 try await provider.request(.즐겨찾기(contentId: id))
             },
             즐겨찾기_취소: { id in
-                try await provider.request(.즐겨찾기_취소(contentId: id))
+                try await provider.requestNoBody(.즐겨찾기_취소(contentId: id))
             },
             카테고리_내_컨텐츠_목록_조회: { id, pageable, condition in
                 try await provider.request(
@@ -104,7 +104,7 @@ extension ContentClient: DependencyKey {
             컨텐츠_수정: { _, _ in .mock },
             컨텐츠_추가: { _ in .mock },
             즐겨찾기: { _ in .mock },
-            즐겨찾기_취소: { _ in .init() },
+            즐겨찾기_취소: { _ in },
             카테고리_내_컨텐츠_목록_조회: { _, _, _ in .mock },
             미분류_카테고리_컨텐츠_조회: { _ in .mock },
             컨텐츠_검색: { _, _ in .mock }

--- a/Projects/CoreKit/Sources/Data/Network/Remind/RemindEndpoint.swift
+++ b/Projects/CoreKit/Sources/Data/Network/Remind/RemindEndpoint.swift
@@ -53,7 +53,7 @@ extension RemindEndpoint: TargetType {
                 parameters: [
                     "page": model.page,
                     "size": model.size,
-                    "sort": model.sort
+                    "sort": model.sort.map { String($0) }.joined(separator: ",")
                 ],
                 encoding: URLEncoding.default
             )

--- a/Projects/CoreKit/Sources/Data/Network/User/UserClient.swift
+++ b/Projects/CoreKit/Sources/Data/Network/User/UserClient.swift
@@ -22,6 +22,7 @@ public struct UserClient {
     public var 회원등록: @Sendable (_ model: SignupRequest) async throws -> BaseUserResponse
     public var 닉네임_중복_체크: @Sendable (_ nickname: String) async throws -> NicknameCheckResponse
     public var 관심사_목록_조회: @Sendable () async throws -> [InterestResponse]
+    public var 닉네임_조회: @Sendable () async throws -> BaseUserResponse
 }
 
 extension UserClient: DependencyKey {
@@ -40,6 +41,9 @@ extension UserClient: DependencyKey {
             },
             관심사_목록_조회: {
                 try await provider.request(.관심사_목록_조회)
+            },
+            닉네임_조회: {
+                try await provider.request(.닉네임_조회)
             }
         )
     }()
@@ -49,7 +53,8 @@ extension UserClient: DependencyKey {
             닉네임_수정: { _ in .mock },
             회원등록: { _ in .mock },
             닉네임_중복_체크: { _ in .mock },
-            관심사_목록_조회: { InterestResponse.mock }
+            관심사_목록_조회: { InterestResponse.mock },
+            닉네임_조회: { .mock }
         )
     }()
 }

--- a/Projects/CoreKit/Sources/Data/Network/User/UserEndpoint.swift
+++ b/Projects/CoreKit/Sources/Data/Network/User/UserEndpoint.swift
@@ -15,6 +15,7 @@ public enum UserEndpoint {
     case 회원등록(model: SignupRequest)
     case 닉네임_중복_체크(nickname: String)
     case 관심사_목록_조회
+    case 닉네임_조회
 }
 
 extension UserEndpoint: TargetType {
@@ -24,7 +25,7 @@ extension UserEndpoint: TargetType {
     
     public var path: String {
         switch self {
-        case .닉네임_수정:
+        case .닉네임_수정, .닉네임_조회:
             return "/nickname"
         case .회원등록:
             return "/signup"
@@ -44,7 +45,8 @@ extension UserEndpoint: TargetType {
             return .post
         
         case .닉네임_중복_체크,
-             .관심사_목록_조회:
+             .관심사_목록_조회,
+             .닉네임_조회:
             return .get
         }
     }
@@ -56,7 +58,8 @@ extension UserEndpoint: TargetType {
         case let .회원등록(model):
             return .requestJSONEncodable(model)
         case .닉네임_중복_체크,
-             .관심사_목록_조회:
+             .관심사_목록_조회,
+             .닉네임_조회:
             return .requestPlain
         }
     }

--- a/Projects/DSKit/Sources/Components/PokitLinkCard.swift
+++ b/Projects/DSKit/Sources/Components/PokitLinkCard.swift
@@ -86,7 +86,7 @@ public struct PokitLinkCard<Item: PokitLinkCardItem>: View {
                 state: isUnCategorized ? .unCategorized : .default
             )
             
-            if !link.isRead {
+            if let isRead = link.isRead, !isRead {
                 PokitBadge("안읽음", state: .unRead)
             }
         }

--- a/Projects/Domain/Sources/Base/BaseContentItem.swift
+++ b/Projects/Domain/Sources/Base/BaseContentItem.swift
@@ -18,7 +18,7 @@ public struct BaseContentItem: Identifiable, Equatable, PokitLinkCardItem, Sorta
     public let data: String
     public let domain: String
     public let createdAt: String
-    public let isRead: Bool
+    public let isRead: Bool?
     
     public init(
         id: Int,
@@ -29,7 +29,7 @@ public struct BaseContentItem: Identifiable, Equatable, PokitLinkCardItem, Sorta
         data: String,
         domain: String,
         createdAt: String,
-        isRead: Bool
+        isRead: Bool?
     ) {
         self.id = id
         self.categoryName = categoryName

--- a/Projects/Domain/Sources/Base/BaseUser.swift
+++ b/Projects/Domain/Sources/Base/BaseUser.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct BaseUser {
+public struct BaseUser: Equatable {
     public let id: Int
     public let email: String
     public let nickname: String

--- a/Projects/Domain/Sources/ContentList/ContentList.swift
+++ b/Projects/Domain/Sources/ContentList/ContentList.swift
@@ -22,7 +22,7 @@ public struct ContentList: Equatable {
         )
         self.pageable = .init(
             page: 0, size: 10,
-            sort: ["desc"]
+            sort: ["createdAt,desc"]
         )
     }
 }

--- a/Projects/Domain/Sources/DTO/User/BaseUserResponse+Extension.swift
+++ b/Projects/Domain/Sources/DTO/User/BaseUserResponse+Extension.swift
@@ -1,0 +1,20 @@
+//
+//  BaseUserResponse+Extension.swift
+//  Domain
+//
+//  Created by 김도형 on 8/25/24.
+//
+
+import Foundation
+
+import CoreKit
+
+public extension BaseUserResponse {
+    func toDomain() -> BaseUser {
+        return .init(
+            id: self.id,
+            email: self.email,
+            nickname: self.nickname
+        )
+    }
+}

--- a/Projects/Domain/Sources/NicknameSetting/NicknameSetting.swift
+++ b/Projects/Domain/Sources/NicknameSetting/NicknameSetting.swift
@@ -10,9 +10,10 @@ import Foundation
 public struct NicknameSetting: Equatable {
     // - MARK: Response
     /// 유저 정보
-//    public let user: BaseUser
+    public var user: BaseUser? = nil
     /// 닉네임 중복 여부
     public var isDuplicate: Bool
+    
     // - MARK: Request
     /// 등록할 닉네임
     public var nickname: String

--- a/Projects/Domain/Sources/Pokit/Pokit.swift
+++ b/Projects/Domain/Sources/Pokit/Pokit.swift
@@ -14,20 +14,26 @@ public struct Pokit: Equatable {
     /// 컨텐트(링크) 리스트
     public var unclassifiedContentList: BaseContentListInquiry
     
+    public var pageable: BasePageable
+    
     public init() {
         self.categoryList = .init(
-            data: [],
             page: 0,
             size: 10,
             sort: [],
             hasNext: false
         )
         self.unclassifiedContentList = .init(
-            data: [],
             page: 0,
             size: 10,
             sort: [],
             hasNext: false
+        )
+        
+        self.pageable = .init(
+            page: -1,
+            size: 10,
+            sort: ["createdAt,desc"]
         )
     }
 }

--- a/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailFeature.swift
+++ b/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailFeature.swift
@@ -38,6 +38,7 @@ public struct ContentDetailFeature {
         var linkTitle: String? = nil
         var linkImageURL: String? = nil
         var showAlert: Bool = false
+        var showLinkPreview = false
     }
     
     /// - Action
@@ -70,6 +71,7 @@ public struct ContentDetailFeature {
             case 컨텐츠_상세_조회(content: BaseContentDetail)
             case 즐겨찾기_갱신(Bool)
             case 카테고리_갱신(BaseCategory)
+            case 링크미리보기_presented
         }
         
         public enum AsyncAction: Equatable {
@@ -165,7 +167,9 @@ private extension ContentDetailFeature {
         case .fetchMetadata(url: let url):
             return .run { send in
                 /// - 링크에 대한 메타데이터의 제목 및 썸네일 항목 파싱
-                let (title, imageURL) = await swiftSoup.parseOGTitleAndImage(url)
+                let (title, imageURL) = await swiftSoup.parseOGTitleAndImage(url) {
+                    await send(.inner(.링크미리보기_presented))
+                }
                 await send(
                     .inner(.parsingInfo(title: title, imageURL: imageURL)),
                     animation: .smooth
@@ -179,6 +183,7 @@ private extension ContentDetailFeature {
             guard let urlString = state.domain.content?.data,
                   let url = URL(string: urlString) else {
                 /// 🚨 Error Case [1]: 올바른 링크가 아닐 때
+                state.showLinkPreview = false
                 state.linkTitle = nil
                 state.linkImageURL = nil
                 return .none
@@ -195,6 +200,9 @@ private extension ContentDetailFeature {
             return .none
         case .카테고리_갱신(let category):
             state.domain.category = category
+            return .none
+        case .링크미리보기_presented:
+            state.showLinkPreview = true
             return .none
         }
     }

--- a/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailFeature.swift
+++ b/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailFeature.swift
@@ -215,7 +215,7 @@ private extension ContentDetailFeature {
             }
         case .즐겨찾기_취소(id: let id):
             return .run { send in
-                let _ = try await contentClient.즐겨찾기_취소("\(id)")
+                try await contentClient.즐겨찾기_취소("\(id)")
                 await send(.inner(.즐겨찾기_갱신(false)))
             }
         case .카테고리_상세_조회(id: let id):

--- a/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailView.swift
+++ b/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailView.swift
@@ -119,9 +119,9 @@ private extension ContentDetailView {
     @ViewBuilder
     func contentLinkPreview(content: BaseContentDetail) -> some View {
         VStack(spacing: 16) {
-            if let title = store.linkTitle {
+            if store.showLinkPreview {
                 PokitLinkPreview(
-                    title: title,
+                    title: store.linkTitle ?? content.title,
                     url: content.data,
                     imageURL: store.linkImageURL ?? "https://pokit-storage.s3.ap-northeast-2.amazonaws.com/logo/pokit.png"
                 )

--- a/Projects/Feature/FeatureContentList/Sources/ContentList/ContentListView.swift
+++ b/Projects/Feature/FeatureContentList/Sources/ContentList/ContentListView.swift
@@ -61,9 +61,9 @@ private extension ContentListView {
             Spacer()
             
             PokitIconLTextLink(
-                store.isListAscending ? "최신순" : "오래된순",
+                store.isListDescending ? "최신순" : "오래된순",
                 icon: .icon(.align),
-                action: { }
+                action: { send(.sortTextLinkTapped) }
             )
             .contentTransition(.numericText())
         }

--- a/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingView.swift
+++ b/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingView.swift
@@ -99,9 +99,9 @@ private extension ContentSettingView {
     }
     var linkTextField: some View {
         VStack(spacing: 16) {
-            if let title = store.linkTitle {
+            if store.showLinkPreview {
                 PokitLinkPreview(
-                    title: title,
+                    title: store.linkTitle ?? "제목을 입력해주세요",
                     url: store.urlText,
                     imageURL: store.linkImageURL ?? "https://pokit-storage.s3.ap-northeast-2.amazonaws.com/logo/pokit.png"
                 )

--- a/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingView.swift
+++ b/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingView.swift
@@ -62,7 +62,7 @@ public extension ContentSettingView {
                     }
                 }
                 
-                let isDisable = store.urlText.isEmpty || store.title.isEmpty
+                let isDisable = store.urlText.isEmpty || store.title.isEmpty || store.memoTextAreaState == .error(message: "최대 100자까지 입력가능합니다.")
                 
                 PokitBottomButton(
                     "저장하기",

--- a/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingView.swift
+++ b/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingView.swift
@@ -52,11 +52,18 @@ public extension ContentSettingView {
                         .padding(.top, 16)
                     }
                     .overlay(alignment: .bottom) {
-                        if store.state.showPopup {
+                        if store.state.showMaxCategoryPopup {
                             PokitLinkPopup(
                                 "최대 30개의 포킷을 생성할 수 있습니다. \n포킷을 삭제한 뒤에 추가해주세요.",
-                                isPresented: $store.showPopup,
+                                isPresented: $store.showMaxCategoryPopup,
                                 type: .text
+                            )
+                        } else if store.state.showDetectedURLPopup {
+                            PokitLinkPopup(
+                                "복사한 링크 저장하기",
+                                isPresented: $store.showDetectedURLPopup,
+                                type: .link(url: store.link ?? ""),
+                                action: { send(.linkCopyButtonTapped, animation: .pokitSpring) }
                             )
                         }
                     }

--- a/Projects/Feature/FeaturePokit/Sources/PokitRootType.swift
+++ b/Projects/Feature/FeaturePokit/Sources/PokitRootType.swift
@@ -16,5 +16,6 @@ public enum PokitRootFilterType: Equatable {
     public enum Sort {
         case 최신순
         case 이름순
+        case 오래된순
     }
 }

--- a/Projects/Feature/FeatureSetting/Sources/Setting/NickNameSetting/NickNameSettingView.swift
+++ b/Projects/Feature/FeatureSetting/Sources/Setting/NickNameSetting/NickNameSettingView.swift
@@ -26,15 +26,19 @@ public extension NickNameSettingView {
     var body: some View {
         WithPerceptionTracking {
             VStack(spacing: 0) {
-                PokitTextInput(
-                    text: $store.text,
-                    state: $store.textfieldState,
-                    info: "한글, 영어, 숫자로만 입력이 가능합니다.",
-                    maxLetter: 10,
-                    focusState: $isFocused,
-                    equals: true
-                )
-                Spacer()
+                if store.user == nil {
+                    PokitLoading()
+                } else {
+                    PokitTextInput(
+                        text: $store.text,
+                        state: $store.textfieldState,
+                        info: "한글, 영어, 숫자로만 입력이 가능합니다.",
+                        maxLetter: 10,
+                        focusState: $isFocused,
+                        equals: true
+                    )
+                    Spacer()
+                }
             }
             .overlay(alignment: .bottom) {
                 PokitBottomButton(
@@ -48,6 +52,7 @@ public extension NickNameSettingView {
             .padding(.top, 16)
             .pokitNavigationBar { navigationBar }
             .ignoresSafeArea(edges: .bottom)
+            .task { await send(.onAppear).finish() }
         }
     }
 }

--- a/Projects/Util/Sources/Protocols/PokitLinkCardItem.swift
+++ b/Projects/Util/Sources/Protocols/PokitLinkCardItem.swift
@@ -12,7 +12,7 @@ public protocol PokitLinkCardItem {
     var thumbNail: String { get }
     var createdAt: String { get }
     var categoryName: String { get }
-    var isRead: Bool { get }
+    var isRead: Bool? { get }
     var data: String { get }
     var domain: String { get }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #92 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

 - 미분류 컨텐츠 목록 정렬 버튼 이름순 -> 오래된순 이름으로 변경
 - 즐겨찾기 해제 api response 처리 수정
 - 안읽음, 즐겨찾기 컨텐츠 목록 정렬 기능 추가
 - 안읽음, 즐겨찾기 컨텐츠 목록 페이지네이션 기능 추가
 - 컨텐츠 수정/추가에서 메모 100자 넘어갈 시 저장버튼 비활성화
 - 미분류 <-> 포킷 전환시 포킷 목록 조회 추가
 - 닉네임 수정 시 사용자 닉네임 텍스트 필드에 반영 추가
 - 링크 추가 화면에서 복사한 링크 자동입력 -> 팝업 노출로 변경
 - 링크 추가/수정 시 링크에 대한 제목 파싱 실패 시 링크 미리보기에 "제목을 입력해주세요" 문구 삽입

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
- 정렬 관련해서 구체적인 기획이 정해짐에 따라, PokitFeature에서 정렬 로직을 변경하였습니다. 목록이 초기화 되는 시점은 포킷 <-> 미분류 전환, 정렬 버튼 클릭 2가지 경우입니다.
- 정렬 로직을 변경한 후, 목록들을 갱신하는 시점에서 뷰를 업데이트 하면서, 뷰의 계층, 애니메이션 처리 등으로 인하여, ui 성능이 심각하게 하락하는 현상이 있었습니다. 때문에, 전환 애니메이션과, PokitRootView의 뷰 계층을 수정하였습니다.
- 닉네임 조회를 구현하면서, 한글로 되어 있지만 자음과 모음이 분리된 닉네임(ex: ㄱㅣㅁㄷㅗㅎㅕㅇ)은 올바르지 않은 닉네임이라고 뜨는데, 의도하신건지 궁금합니다!(그래서 건들지 않았음)

close 이슈번호
