### PR TITLE
Fix: 디자이너 QA

### DIFF
--- a/Projects/App/Sources/MainTab/MainTabFeatureView.swift
+++ b/Projects/App/Sources/MainTab/MainTabFeatureView.swift
@@ -241,14 +241,14 @@ private extension MainTabView {
         .padding(.top, 30)
         .overlay(alignment: .top) {
             Button(action: { send(.addButtonTapped) }) {
-                Circle()
-                    .foregroundStyle(.pokit(.bg(.brand)))
-                    .overlay {
-                        Image(.icon(.plus))
-                            .resizable()
-                            .frame(width: 36, height: 36)
-                            .padding(11)
-                            .foregroundStyle(.pokit(.icon(.inverseWh)))
+                Image(.icon(.plus))
+                    .resizable()
+                    .frame(width: 36, height: 36)
+                    .padding(12)
+                    .foregroundStyle(.pokit(.icon(.inverseWh)))
+                    .background {
+                        RoundedRectangle(cornerRadius: 9999, style: .continuous)
+                            .fill(.pokit(.bg(.brand)))
                     }
                     .frame(width: 60, height: 60)
             }

--- a/Projects/App/Sources/MainTab/MainTabFeatureView.swift
+++ b/Projects/App/Sources/MainTab/MainTabFeatureView.swift
@@ -198,31 +198,13 @@ private extension MainTabView {
 
     var bottomTabBar: some View {
         HStack(alignment: .bottom, spacing: 0) {
-            ForEach(MainTab.allCases, id: \.self) { tab in
-                let isSelected: Bool = store.selectedTab == tab
-
-                VStack(spacing: 4) {
-                    Image(tab.icon)
-                        .renderingMode(.template)
-                        .foregroundStyle(
-                            isSelected
-                            ? .pokit(.icon(.primary))
-                            : .pokit(.icon(.tertiary))
-                        )
-                    Text(tab.title)
-                        .foregroundStyle(
-                            isSelected
-                            ? .pokit(.text(.primary))
-                            : .pokit(.text(.tertiary))
-                        )
-                        .pokitFont(.detail2)
-                }
-                .frame(maxWidth: .infinity)
-                .onTapGesture {
-                    store.send(.binding(.set(\.selectedTab, tab)))
-                }
-            }
+            bottomTabBarItem(.pokit)
+            
+            Spacer()
+            
+            bottomTabBarItem(.remind)
         }
+        .padding(.horizontal, 48)
         .padding(.top, 12)
         .padding(.bottom, 36)
         .background {
@@ -255,6 +237,37 @@ private extension MainTabView {
         }
         .animation(.spring, value: store.selectedTab)
     }
+    
+    @ViewBuilder
+    func bottomTabBarItem(_ tab: MainTab) -> some View {
+        let isSelected: Bool = store.selectedTab == tab
+
+        VStack(spacing: 4) {
+            Image(tab.icon)
+                .renderingMode(.template)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 24, height: 24)
+                .foregroundStyle(
+                    isSelected
+                    ? .pokit(.icon(.primary))
+                    : .pokit(.icon(.tertiary))
+                )
+            
+            Text(tab.title)
+                .foregroundStyle(
+                    isSelected
+                    ? .pokit(.text(.primary))
+                    : .pokit(.text(.tertiary))
+                )
+                .pokitFont(.detail2)
+        }
+        .padding(.horizontal, 28)
+        .onTapGesture {
+            store.send(.binding(.set(\.selectedTab, tab)))
+        }
+    }
+    
     struct AddSheet: View {
         @State private var height: CGFloat = 0
         var action: (TabAddSheetType) -> Void

--- a/Projects/App/Sources/MainTab/MainTabFeatureView.swift
+++ b/Projects/App/Sources/MainTab/MainTabFeatureView.swift
@@ -130,7 +130,7 @@ private extension MainTabView {
             }
             .task { await send(.onAppear).finish() }
     }
-
+    
     var tabView: some View {
         TabView(selection: $store.selectedTab) {
             switch store.selectedTab {
@@ -146,7 +146,7 @@ private extension MainTabView {
             }
         }
     }
-
+    
     var pokitNavigationBar: some View {
         PokitHeader {
             PokitHeaderItems(placement: .leading) {
@@ -173,7 +173,7 @@ private extension MainTabView {
         }
         .padding(.vertical, 8)
     }
-
+    
     var remindNavigationBar: some View {
         PokitHeader {
             PokitHeaderItems(placement: .leading) {
@@ -195,7 +195,7 @@ private extension MainTabView {
         }
         .padding(.vertical, 8)
     }
-
+    
     var bottomTabBar: some View {
         HStack(alignment: .bottom, spacing: 0) {
             bottomTabBarItem(.pokit)
@@ -241,7 +241,7 @@ private extension MainTabView {
     @ViewBuilder
     func bottomTabBarItem(_ tab: MainTab) -> some View {
         let isSelected: Bool = store.selectedTab == tab
-
+        
         VStack(spacing: 4) {
             Image(tab.icon)
                 .renderingMode(.template)
@@ -271,36 +271,42 @@ private extension MainTabView {
     struct AddSheet: View {
         @State private var height: CGFloat = 0
         var action: (TabAddSheetType) -> Void
-
+        
         var body: some View {
             HStack(spacing: 20) {
+                Spacer()
+                
                 ForEach(TabAddSheetType.allCases, id: \.self) { type in
                     Button(action: { action(type) }) {
                         VStack(spacing: 4) {
+                            Spacer()
+                            
                             type.icon
                                 .renderingMode(.template)
                                 .resizable()
-                                .frame(width: 24, height: 24)
-                                .foregroundStyle(.pokit(.text(.inverseWh)))
-                                .padding(3.2)
-                                .padding(.horizontal, 8)
+                                .aspectRatio(contentMode: .fit)
+                                .frame(width: 28, height: 28)
+                                .foregroundStyle(.pokit(.icon(.inverseWh)))
+                            
                             Text(type.title)
                                 .pokitFont(.b3(.m))
                                 .foregroundStyle(.pokit(.text(.inverseWh)))
+                            
+                            Spacer()
                         }
-                        .padding(.vertical, 21)
                         .padding(.horizontal, 24)
                         .background {
-                            RoundedRectangle(cornerRadius: 12)
+                            RoundedRectangle(cornerRadius: 12, style: .continuous)
                                 .foregroundStyle(.pokit(.bg(.brand)))
                         }
+                        .frame(height: 96)
                     }
                 }
+                
+                Spacer()
             }
-            .padding(.top)
-            .padding(.top, 24)
-            .padding(.bottom, 12)
-            .background(.white)
+            .padding(.top, 36)
+            .padding(.bottom, 48)
             .pokitPresentationCornerRadius()
             .pokitPresentationBackground()
             .presentationDragIndicator(.visible)
@@ -311,7 +317,6 @@ private extension MainTabView {
                 }
             }
             .presentationDetents([.height(self.height)])
-
         }
     }
 }

--- a/Projects/DSKit/Sources/Components/PokitBottomButton.swift
+++ b/Projects/DSKit/Sources/Components/PokitBottomButton.swift
@@ -71,7 +71,7 @@ public struct PokitBottomButton: View {
                 .stroke(self.state.backgroundStrokeColor, lineWidth: 1)
             }
         }
-        .animation(.smooth, value: self.state)
+        .animation(.pokitDissolve, value: self.state)
     }
 }
 

--- a/Projects/DSKit/Sources/Components/PokitCalendar.swift
+++ b/Projects/DSKit/Sources/Components/PokitCalendar.swift
@@ -47,7 +47,7 @@ public struct PokitCalendar: View {
                 .pokitFont(.b1(.b))
                 .foregroundStyle(.pokit(.text(.primary)))
                 .contentTransition(.numericText())
-                .animation(.pokitSpring, value: self.page)
+                .animation(.pokitDissolve, value: self.page)
             
             Spacer()
             
@@ -96,7 +96,7 @@ public struct PokitCalendar: View {
                 
                 datesOfMonth(width: width)
             }
-            .animation(.smooth, value: self.page)
+            .animation(.pokitDissolve, value: self.page)
             .frame(height: proxy.size.width)
         }
     }
@@ -298,7 +298,7 @@ public struct PokitCalendar: View {
         isEndDate: Bool,
         isContains: Bool
     ) {
-        withAnimation(.smooth) {
+        withAnimation(.pokitDissolve) {
             let ignoreTimeOfStartDate = ignoreTime(self.startDate)
             let ignoreTimeOfEndDate = ignoreTime(self.endDate)
             let isRange = ignoreTimeOfStartDate != ignoreTimeOfEndDate

--- a/Projects/DSKit/Sources/Components/PokitCard.swift
+++ b/Projects/DSKit/Sources/Components/PokitCard.swift
@@ -37,7 +37,7 @@ public struct PokitCard<Item: PokitCardItem>: View {
             HStack {
                 title
                 
-                Spacer()
+                Spacer(minLength: 28)
             }
             .overlay(alignment: .trailing) {
                 kebabButton

--- a/Projects/DSKit/Sources/Components/PokitCard.swift
+++ b/Projects/DSKit/Sources/Components/PokitCard.swift
@@ -100,7 +100,7 @@ public struct PokitCard<Item: PokitCardItem>: View {
                         .frame(width: 48, height: 48)
                 }
             }
-            .animation(.smooth, value: state.image)
+            .animation(.pokitDissolve, value: state.image)
         }
         .frame(width: 84, height: 84)
     }

--- a/Projects/DSKit/Sources/Components/PokitCard.swift
+++ b/Projects/DSKit/Sources/Components/PokitCard.swift
@@ -102,7 +102,7 @@ public struct PokitCard<Item: PokitCardItem>: View {
             }
             .animation(.smooth, value: state.image)
         }
-        .frame(width: 68, height: 68)
+        .frame(width: 84, height: 84)
     }
     
     private var background: some View {

--- a/Projects/DSKit/Sources/Components/PokitCheckBox.swift
+++ b/Projects/DSKit/Sources/Components/PokitCheckBox.swift
@@ -59,11 +59,11 @@ public struct PokitCheckBox: View {
                 RoundedRectangle(cornerRadius: self.shape.radius, style: .continuous)
                     .stroke(self.state.backgroundStrokeColor, lineWidth: 1)
             }
-            .animation(.smooth, value: self.state)
+            .animation(.pokitDissolve, value: self.state)
     }
     
     private func buttonTapped() {
-        withAnimation(.pokitSpring) {
+        withAnimation(.pokitDissolve) {
             isSelected.toggle()
         }
         action?()

--- a/Projects/DSKit/Sources/Components/PokitDeleteBottomSheet.swift
+++ b/Projects/DSKit/Sources/Components/PokitDeleteBottomSheet.swift
@@ -83,7 +83,7 @@ public extension PokitDeleteBottomSheet {
             case .링크삭제:
                 return "함께 저장한 모든 정보가 삭제되며,\n복구하실 수 없습니다."
             case .포킷삭제:
-                return "함께 저장한 모든 포킷이 삭제되며,\n복구하실 수 없습니다."
+                return "함께 저장한 모든 링크가 삭제되며,\n복구하실 수 없습니다."
             }
         }
     }

--- a/Projects/DSKit/Sources/Components/PokitIconLInput.swift
+++ b/Projects/DSKit/Sources/Components/PokitIconLInput.swift
@@ -94,7 +94,7 @@ public struct PokitIconLInput<Value: Hashable>: View {
                 .resizable()
                 .frame(width: 24, height: 24)
                 .foregroundStyle(state.iconColor)
-                .animation(.smooth, value: self.state)
+                .animation(.pokitDissolve, value: self.state)
         }
     }
     

--- a/Projects/DSKit/Sources/Components/PokitIconRInput.swift
+++ b/Projects/DSKit/Sources/Components/PokitIconRInput.swift
@@ -94,7 +94,7 @@ public struct PokitIconRInput<Value: Hashable>: View {
                 .resizable()
                 .frame(width: 24, height: 24)
                 .foregroundStyle(state.iconColor)
-                .animation(.smooth, value: self.state)
+                .animation(.pokitDissolve, value: self.state)
         }
     }
     

--- a/Projects/DSKit/Sources/Components/PokitLinkCard.swift
+++ b/Projects/DSKit/Sources/Components/PokitLinkCard.swift
@@ -119,7 +119,7 @@ public struct PokitLinkCard<Item: PokitLinkCardItem>: View {
                     }
                 }
             }
-            .animation(.smooth, value: phase.image)
+            .animation(.pokitDissolve, value: phase.image)
         }
         .frame(width: 124, height: 94)
         .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))

--- a/Projects/DSKit/Sources/Components/PokitLinkPreview.swift
+++ b/Projects/DSKit/Sources/Components/PokitLinkPreview.swift
@@ -47,7 +47,7 @@ public struct PokitLinkPreview: View {
                             .frame(width: 48, height: 48)
                     }
                 }
-                .animation(.smooth, value: phase.image)
+                .animation(.pokitDissolve, value: phase.image)
             }
             .frame(width: 124, height: 108)
             

--- a/Projects/DSKit/Sources/Components/PokitList.swift
+++ b/Projects/DSKit/Sources/Components/PokitList.swift
@@ -81,6 +81,6 @@ public struct PokitList<Item: PokitSelectItem>: View {
                 }
             }
         }
-        .animation(.smooth, value: isSelected)
+        .animation(.pokitDissolve, value: isSelected)
     }
 }

--- a/Projects/DSKit/Sources/Components/PokitList.swift
+++ b/Projects/DSKit/Sources/Components/PokitList.swift
@@ -73,7 +73,7 @@ public struct PokitList<Item: PokitSelectItem>: View {
             }
             .padding(.leading, 28)
             .padding(.trailing, 20)
-            .padding(.vertical, 18)
+            .padding(.vertical, 13)
             .background {
                 if isSelected {
                     Color.pokit(.bg(.primary))

--- a/Projects/DSKit/Sources/Components/PokitPartSwitchRadio.swift
+++ b/Projects/DSKit/Sources/Components/PokitPartSwitchRadio.swift
@@ -77,6 +77,7 @@ public struct PokitPartSwitchRadio<Selection: Equatable>: View {
             }
     }
     
+    @ViewBuilder
     public func background() -> some View {
         self
             .background {
@@ -86,9 +87,10 @@ public struct PokitPartSwitchRadio<Selection: Equatable>: View {
                     self.background(.default(self.style))
                 }
             }
-            .animation(.smooth, value: self.selection)
+            .animation(.pokitDissolve, value: self.selection)
     }
     
+    @ViewBuilder
     public func matchedGeometryEffectBackground(
         id: Namespace.ID
     ) -> some View {

--- a/Projects/DSKit/Sources/Components/PokitPartTap.swift
+++ b/Projects/DSKit/Sources/Components/PokitPartTap.swift
@@ -34,7 +34,7 @@ public struct PokitPartTap<Selection: Equatable>: View {
     
     private var tapButton: some View {
         Button {
-            withAnimation(.smooth) {
+            withAnimation(.pokitDissolve) {
                 selection = current
             }
             action?()
@@ -65,6 +65,18 @@ public struct PokitPartTap<Selection: Equatable>: View {
             .frame(height: 2)
     }
     
+    @ViewBuilder
+    public func backgound() -> some View {
+        self
+            .background(alignment: .bottom) {
+                if isSelected {
+                    self.selectedBackground
+                }
+            }
+            .animation(.pokitDissolve, value: self.selection)
+    }
+    
+    @ViewBuilder
     public func matchedGeometryEffectBackground(
         id: Namespace.ID
     ) -> some View {
@@ -75,6 +87,6 @@ public struct PokitPartTap<Selection: Equatable>: View {
                         .matchedGeometryEffect(id: "SELECT", in: id)
                 }
             }
-            .animation(.smooth, value: self.selection)
+            .animation(.pokitDissolve, value: self.selection)
     }
 }

--- a/Projects/DSKit/Sources/Components/PokitSelect.swift
+++ b/Projects/DSKit/Sources/Components/PokitSelect.swift
@@ -50,7 +50,7 @@ public struct PokitSelect<Item: PokitSelectItem>: View {
             listSheet
                 .presentationDragIndicator(.visible)
                 .pokitPresentationCornerRadius()
-                .presentationDetents([.medium, .large])
+                .presentationDetents([.medium])
                 .pokitPresentationBackground()
         }
     }
@@ -103,7 +103,7 @@ public struct PokitSelect<Item: PokitSelectItem>: View {
                     action(item)
                     listCellTapped(item)
                 }
-                .padding(.top, 24)
+                .padding(.top, 36)
                 .padding(.bottom, 20)
             } else {
                 PokitLoading()

--- a/Projects/DSKit/Sources/Components/PokitSelect.swift
+++ b/Projects/DSKit/Sources/Components/PokitSelect.swift
@@ -90,7 +90,7 @@ public struct PokitSelect<Item: PokitSelectItem>: View {
                 RoundedRectangle(cornerRadius: 8, style: .continuous)
                     .stroke(self.state.backgroundStrokeColor, lineWidth: 1)
             }
-            .animation(.smooth, value: self.state)
+            .animation(.pokitDissolve, value: self.state)
     }
     
     private var listSheet: some View {
@@ -116,7 +116,7 @@ public struct PokitSelect<Item: PokitSelectItem>: View {
     }
     
     private func listCellTapped(_ item: Item) {
-        withAnimation(.smooth) {
+        withAnimation(.pokitDissolve) {
             self.selectedItem = item
         }
         showSheet = false

--- a/Projects/DSKit/Sources/Components/PokitTextArea.swift
+++ b/Projects/DSKit/Sources/Components/PokitTextArea.swift
@@ -77,7 +77,7 @@ public struct PokitTextArea<Value: Hashable>: View {
                         .resizable()
                         .foregroundStyle(.pokit(.icon(.error)))
                         .frame(width: 20, height: 20)
-                        .pokitBlurReplaceTransition(.smooth)
+                        .pokitBlurReplaceTransition(.pokitDissolve)
                     
                     Text(message)
                         .foregroundStyle(.pokit(.text(.error)))
@@ -89,7 +89,7 @@ public struct PokitTextArea<Value: Hashable>: View {
                 }
             }
             .pokitFont(.detail1)
-            .pokitBlurReplaceTransition(.smooth)
+            .pokitBlurReplaceTransition(.pokitDissolve)
             
             Spacer()
             
@@ -105,7 +105,7 @@ public struct PokitTextArea<Value: Hashable>: View {
             }
             .pokitFont(.detail1)
             .contentTransition(.numericText())
-            .animation(.smooth, value: text)
+            .animation(.pokitDissolve, value: text)
         }
         .padding(.top, 4)
     }

--- a/Projects/DSKit/Sources/Components/PokitTextInput.swift
+++ b/Projects/DSKit/Sources/Components/PokitTextInput.swift
@@ -95,7 +95,7 @@ public struct PokitTextInput<Value: Hashable>: View {
                         .resizable()
                         .foregroundStyle(.pokit(.icon(.error)))
                         .frame(width: 20, height: 20)
-                        .pokitBlurReplaceTransition(.smooth)
+                        .pokitBlurReplaceTransition(.pokitDissolve)
                     
                     Text(message)
                         .foregroundStyle(.pokit(.text(.error)))
@@ -107,7 +107,7 @@ public struct PokitTextInput<Value: Hashable>: View {
                 }
             }
             .pokitFont(.detail1)
-            .pokitBlurReplaceTransition(.smooth)
+            .pokitBlurReplaceTransition(.pokitDissolve)
             
             Spacer()
             
@@ -124,7 +124,7 @@ public struct PokitTextInput<Value: Hashable>: View {
                 }
                 .pokitFont(.detail1)
                 .contentTransition(.numericText())
-                .animation(.smooth, value: text)
+                .animation(.pokitDissolve, value: text)
             }
         }
         .padding(.top, 4)

--- a/Projects/DSKit/Sources/Extensions/Animation+Extension.swift
+++ b/Projects/DSKit/Sources/Extensions/Animation+Extension.swift
@@ -11,4 +11,8 @@ public extension Animation {
     static var pokitSpring: Animation {
         return .spring(bounce: 0.3)
     }
+    
+    static var pokitDissolve: Animation {
+        return .easeInOut(duration: 0.2)
+    }
 }

--- a/Projects/DSKit/Sources/Modifiers/PokitInputModifier.swift
+++ b/Projects/DSKit/Sources/Modifiers/PokitInputModifier.swift
@@ -32,7 +32,7 @@ struct PokitInputModifier: ViewModifier {
                             .stroke(backgroundStrokeColor, lineWidth: 1)
                     }
             }
-            .animation(.smooth, value: state)
+            .animation(.pokitDissolve, value: state)
     }
 }
 

--- a/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailFeature.swift
+++ b/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailFeature.swift
@@ -268,7 +268,7 @@ private extension CategoryDetailFeature {
                         favorites: condition.isFavoriteFlitered
                     )
                 ).toDomain()
-                await send(.inner(.카테고리_내_컨텐츠_목록_갱신(contentList)), animation: .smooth)
+                await send(.inner(.카테고리_내_컨텐츠_목록_갱신(contentList)), animation: .pokitDissolve)
             }
         case .컨텐츠_삭제(id: let id):
             return .run { [id] send in
@@ -359,7 +359,7 @@ private extension CategoryDetailFeature {
                 state.sortType = type
                 state.domain.condition.isFavoriteFlitered = bookMarkSelected
                 state.domain.condition.isUnreadFlitered = unReadSelected
-                return .send(.async(.카테고리_내_컨텐츠_목록_조회), animation: .smooth)
+                return .send(.async(.카테고리_내_컨텐츠_목록_조회), animation: .pokitDissolve)
             }
         }
     }

--- a/Projects/Feature/FeatureCategorySetting/Sources/Sheet/ProfileBottomSheet.swift
+++ b/Projects/Feature/FeatureCategorySetting/Sources/Sheet/ProfileBottomSheet.swift
@@ -42,7 +42,7 @@ public extension ProfileBottomSheet {
                 ForEach(images) { item in
                     LazyImage(
                         url: URL(string: item.imageURL),
-                        transaction: .init(animation: .smooth)
+                        transaction: .init(animation: .pokitDissolve)
                     ) { phase in
                         if let image = phase.image {
                             Button(action: { delegateSend?(.imageSelected(item)) }) {

--- a/Projects/Feature/FeatureCategorySetting/Sources/Sheet/ProfileBottomSheet.swift
+++ b/Projects/Feature/FeatureCategorySetting/Sources/Sheet/ProfileBottomSheet.swift
@@ -16,9 +16,9 @@ public struct ProfileBottomSheet: View {
     @State private var images: [BaseCategoryImage]
     let selectedImage: BaseCategoryImage?
     private let colmumns = [
-        GridItem(.fixed(66), spacing: 20),
-        GridItem(.fixed(66), spacing: 20),
-        GridItem(.fixed(66), spacing: 0)
+        GridItem(.fixed(72), spacing: 20),
+        GridItem(.fixed(72), spacing: 20),
+        GridItem(.fixed(72), spacing: 0)
     ]
     private let delegateSend: ((ProfileBottomSheet.Delegate) -> Void)?
     
@@ -48,12 +48,12 @@ public extension ProfileBottomSheet {
                             Button(action: { delegateSend?(.imageSelected(item)) }) {
                                 image
                                     .resizable()
-                                    .roundedCorner(12, corners: .allCorners)
+                                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
                             }
                             .buttonStyle(.plain)
                             .overlay {
                                 if let selectedImage, item.imageURL == selectedImage.imageURL {
-                                    RoundedRectangle(cornerRadius: 12)
+                                    RoundedRectangle(cornerRadius: 12, style: .continuous)
                                         .stroke(.pokit(.border(.brand)), lineWidth: 2)
                                 }
                             }
@@ -63,19 +63,17 @@ public extension ProfileBottomSheet {
                                 .frame(width: 48, height: 48)
                         }
                     }
-                    .frame(width: 66, height: 66)
+                    .frame(width: 72, height: 72)
                     
                 }
             }
             .padding(.vertical, 12)
             .background(.white)
         }
-        .padding(.top)
-        .padding(.top, 26)
-        .padding(.bottom, 36)
+        .padding(.top, 36)
+        .padding(.bottom, 28)
         .fixedSize(horizontal: false, vertical: true)
         .scrollIndicators(.hidden)
-        .ignoresSafeArea(edges: .bottom)
         .background(.pokit(.bg(.base)))
         .pokitPresentationCornerRadius()
         .pokitPresentationBackground()
@@ -87,6 +85,7 @@ public extension ProfileBottomSheet {
             }
         }
         .presentationDetents([.height(height)])
+        .ignoresSafeArea(edges: .bottom)
     }
 }
 //MARK: - Delegate

--- a/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailFeature.swift
+++ b/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailFeature.swift
@@ -10,6 +10,7 @@ import ComposableArchitecture
 import Domain
 import CoreKit
 import Util
+import DSKit
 
 @Reducer
 public struct ContentDetailFeature {
@@ -172,7 +173,7 @@ private extension ContentDetailFeature {
                 }
                 await send(
                     .inner(.parsingInfo(title: title, imageURL: imageURL)),
-                    animation: .smooth
+                    animation: .pokitDissolve
                 )
             }
         case let .parsingInfo(title: title, imageURL: imageURL):
@@ -188,7 +189,7 @@ private extension ContentDetailFeature {
                 state.linkImageURL = nil
                 return .none
             }
-            return .send(.inner(.fetchMetadata(url: url)), animation: .smooth)
+            return .send(.inner(.fetchMetadata(url: url)), animation: .pokitDissolve)
         case .dismissAlert:
             state.showAlert = false
             return .none

--- a/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailView.swift
+++ b/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailView.swift
@@ -159,7 +159,7 @@ private extension ContentDetailView {
         Button(action: { send(.favoriteButtonTapped, animation: .smooth) }) {
             let isFavorite = content.favorites
             
-            Image(isFavorite ? .icon(.starFill) : .icon(.star))
+            Image(isFavorite ? .icon(.starFill) : .icon(.starFill))
                 .resizable()
                 .scaledToFit()
                 .foregroundStyle(.pokit(.icon(isFavorite ? .brand : .tertiary)))

--- a/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailView.swift
+++ b/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailView.swift
@@ -190,7 +190,7 @@ private extension ContentDetailView {
             )
         }
         .padding(.top, 12)
-        .padding(.bottom, 34)
+        .padding(.bottom, 40)
         .padding(.horizontal, 16)
         .background(.pokit(.bg(.base)))
         .overlay(alignment: .top) {

--- a/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailView.swift
+++ b/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailView.swift
@@ -134,12 +134,21 @@ private extension ContentDetailView {
     
     @ViewBuilder
     func contentMemo(content: BaseContentDetail) -> some View {
+        let isEmpty = content.memo.isEmpty
+        
         HStack {
             VStack {
-                Text(content.memo)
-                    .pokitFont(.b3(.r))
-                    .foregroundStyle(.pokit(.text(.primary)))
-                    .multilineTextAlignment(.leading)
+                Group {
+                    if isEmpty {
+                        Text("메모를 작성해보세요.")
+                            .foregroundStyle(.pokit(.text(.tertiary)))
+                    } else {
+                        Text(content.memo)
+                            .foregroundStyle(.pokit(.text(.primary)))
+                    }
+                }
+                .pokitFont(.b3(.r))
+                .multilineTextAlignment(.leading)
                 
                 Spacer()
             }

--- a/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailView.swift
+++ b/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailView.swift
@@ -41,9 +41,8 @@ public extension ContentDetailView {
                     PokitLoading()
                 }
             }
-            .padding(.top, 28)
+            .padding(.vertical, 28)
             .ignoresSafeArea(edges: .bottom)
-            .padding(.bottom, 40)
             .background(.pokit(.bg(.base)))
             .pokitPresentationBackground()
             .pokitPresentationCornerRadius()
@@ -191,6 +190,7 @@ private extension ContentDetailView {
             )
         }
         .padding(.top, 12)
+        .padding(.bottom, 6)
         .padding(.horizontal, 16)
         .background(.pokit(.bg(.base)))
         .overlay(alignment: .top) {

--- a/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailView.swift
+++ b/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailView.swift
@@ -41,7 +41,7 @@ public extension ContentDetailView {
                     PokitLoading()
                 }
             }
-            .padding(.vertical, 28)
+            .padding(.top, 28)
             .ignoresSafeArea(edges: .bottom)
             .background(.pokit(.bg(.base)))
             .pokitPresentationBackground()
@@ -190,7 +190,7 @@ private extension ContentDetailView {
             )
         }
         .padding(.top, 12)
-        .padding(.bottom, 6)
+        .padding(.bottom, 34)
         .padding(.horizontal, 16)
         .background(.pokit(.bg(.base)))
         .overlay(alignment: .top) {

--- a/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailView.swift
+++ b/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailView.swift
@@ -57,7 +57,7 @@ public extension ContentDetailView {
                 )
             }
             .task {
-                await send(.contentDetailViewOnAppeared, animation: .smooth).finish()
+                await send(.contentDetailViewOnAppeared, animation: .pokitDissolve).finish()
             }
         }
     }
@@ -124,7 +124,7 @@ private extension ContentDetailView {
                     url: content.data,
                     imageURL: store.linkImageURL ?? "https://pokit-storage.s3.ap-northeast-2.amazonaws.com/logo/pokit.png"
                 )
-                .pokitBlurReplaceTransition(.smooth)
+                .pokitBlurReplaceTransition(.pokitDissolve)
             }
             
             contentMemo(content: content)
@@ -165,7 +165,7 @@ private extension ContentDetailView {
     
     @ViewBuilder
     func favorite(content: BaseContentDetail) -> some View {
-        Button(action: { send(.favoriteButtonTapped, animation: .smooth) }) {
+        Button(action: { send(.favoriteButtonTapped, animation: .pokitDissolve) }) {
             let isFavorite = content.favorites
             
             Image(isFavorite ? .icon(.starFill) : .icon(.starFill))

--- a/Projects/Feature/FeatureContentList/Sources/ContentList/ContentListFeature.swift
+++ b/Projects/Feature/FeatureContentList/Sources/ContentList/ContentListFeature.swift
@@ -267,6 +267,7 @@ private extension ContentListFeature {
                     break
                 }
             }
+        }
     }
     
     /// - Scope Effect

--- a/Projects/Feature/FeatureContentList/Sources/ContentList/ContentListFeature.swift
+++ b/Projects/Feature/FeatureContentList/Sources/ContentList/ContentListFeature.swift
@@ -174,10 +174,10 @@ private extension ContentListFeature {
             return .run { [type = state.contentType] send in
                 switch type {
                 case .unread:
-                    await send(.async(.읽지않음_컨텐츠_조회), animation: .smooth)
+                    await send(.async(.읽지않음_컨텐츠_조회), animation: .pokitDissolve)
                     break
                 case .favorite:
-                    await send(.async(.즐겨찾기_링크모음_조회), animation: .smooth)
+                    await send(.async(.즐겨찾기_링크모음_조회), animation: .pokitDissolve)
                     break
                 }
                 
@@ -236,7 +236,7 @@ private extension ContentListFeature {
                         sort: pageable.sort
                     )
                 ).toDomain()
-                await send(.inner(.컨텐츠_목록_조회(contentList)), animation: .smooth)
+                await send(.inner(.컨텐츠_목록_조회(contentList)), animation: .pokitDissolve)
             }
         case .즐겨찾기_링크모음_조회:
             return .run { [pageable = state.domain.pageable] send in
@@ -247,7 +247,7 @@ private extension ContentListFeature {
                         sort: pageable.sort
                     )
                 ).toDomain()
-                await send(.inner(.컨텐츠_목록_조회(contentList)), animation: .smooth)
+                await send(.inner(.컨텐츠_목록_조회(contentList)), animation: .pokitDissolve)
             }
         case .컨텐츠_삭제(id: let id):
             return .run { [id] send in
@@ -260,12 +260,13 @@ private extension ContentListFeature {
             return .run { [type = state.contentType] send in
                 switch type {
                 case .unread:
-                    await send(.async(.읽지않음_컨텐츠_조회), animation: .smooth)
+                    await send(.async(.읽지않음_컨텐츠_조회), animation: .pokitDissolve)
+                    break
                 case .favorite:
-                    await send(.async(.즐겨찾기_링크모음_조회), animation: .smooth)
+                    await send(.async(.즐겨찾기_링크모음_조회), animation: .pokitDissolve)
+                    break
                 }
             }
-        }
     }
     
     /// - Scope Effect

--- a/Projects/Feature/FeatureContentList/Sources/ContentList/ContentListView.swift
+++ b/Projects/Feature/FeatureContentList/Sources/ContentList/ContentListView.swift
@@ -46,7 +46,7 @@ public extension ContentListView {
                     confirmText: "삭제"
                 ) { send(.deleteAlertConfirmTapped(content: content)) }
             }
-            .task { await send(.contentListViewOnAppeared, animation: .smooth).finish() }
+            .task { await send(.contentListViewOnAppeared, animation: .pokitDissolve).finish() }
         }
     }
 }

--- a/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingFeature.swift
+++ b/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingFeature.swift
@@ -227,7 +227,7 @@ private extension ContentSettingFeature {
                 }
                 await send(
                     .inner(.parsingInfo(title: title, imageURL: imageURL)),
-                    animation: .smooth
+                    animation: .pokitDissolve
                 )
             }
         case let .parsingInfo(title: title, imageURL: imageURL):
@@ -249,7 +249,7 @@ private extension ContentSettingFeature {
                 state.domain.thumbNail = nil
                 return .none
             }
-            return .send(.inner(.fetchMetadata(url: url)), animation: .smooth)
+            return .send(.inner(.fetchMetadata(url: url)), animation: .pokitDissolve)
         case .showPopup:
             state.showMaxCategoryPopup = true
             return .none
@@ -336,7 +336,7 @@ private extension ContentSettingFeature {
                     ),
                     false
                 ).toDomain()
-                await send(.inner(.카테고리_목록_갱신(categoryList: categoryList)), animation: .smooth)
+                await send(.inner(.카테고리_목록_갱신(categoryList: categoryList)), animation: .pokitDissolve)
             }
         case .컨텐츠_수정:
             guard let contentId = state.domain.contentId else {

--- a/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingView.swift
+++ b/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingView.swift
@@ -16,8 +16,6 @@ public struct ContentSettingView: View {
     public var store: StoreOf<ContentSettingFeature>
     @FocusState
     private var focusedType: FocusedType?
-    @Namespace
-    private var heroEffect
     /// - Initializer
     public init(store: StoreOf<ContentSettingFeature>) {
         self.store = store
@@ -105,7 +103,7 @@ private extension ContentSettingView {
                     url: store.urlText,
                     imageURL: store.linkImageURL ?? "https://pokit-storage.s3.ap-northeast-2.amazonaws.com/logo/pokit.png"
                 )
-                .pokitBlurReplaceTransition(.smooth)
+                .pokitBlurReplaceTransition(.pokitDissolve)
             }
             
             PokitTextInput(
@@ -170,7 +168,7 @@ private extension ContentSettingView {
                     to: .no,
                     style: .stroke
                 )
-                .matchedGeometryEffectBackground(id: heroEffect)
+                .background()
                 
                 PokitPartSwitchRadio(
                     labelText: "받을래요",
@@ -178,7 +176,7 @@ private extension ContentSettingView {
                     to: .yes,
                     style: .stroke
                 )
-                .matchedGeometryEffectBackground(id: heroEffect)
+                .background()
             }
             .padding(.bottom, 8)
             

--- a/Projects/Feature/FeatureLogin/Sources/SelectField/SelectFieldView.swift
+++ b/Projects/Feature/FeatureLogin/Sources/SelectField/SelectFieldView.swift
@@ -80,10 +80,10 @@ extension SelectFieldView {
                     state: isSelected ? .filled(.primary) : isMaxCount ? .disable : .default(.primary),
                     size: .medium
                 ) {
-                    send(.fieldChipTapped(field), animation: .smooth)
+                    send(.fieldChipTapped(field), animation: .pokitDissolve)
                 }
             }
-            .animation(.pokitSpring, value: store.fields)
+            .animation(.pokitDissolve, value: store.fields)
         }
     }
 }

--- a/Projects/Feature/FeatureLogin/Sources/SignUpDone/SignUpDoneView.swift
+++ b/Projects/Feature/FeatureLogin/Sources/SignUpDone/SignUpDoneView.swift
@@ -89,7 +89,7 @@ extension SignUpDoneView {
                 .multilineTextAlignment(.center)
         }
         .opacity(store.titleIsAppear ? 1 : 0)
-        .onAppear { send(.titleOnAppeared, animation: .smooth) }
+        .onAppear { send(.titleOnAppeared, animation: .pokitDissolve) }
     }
     
     private var images: some View {

--- a/Projects/Feature/FeaturePokit/Sources/PokitRootFeature.swift
+++ b/Projects/Feature/FeaturePokit/Sources/PokitRootFeature.swift
@@ -321,7 +321,7 @@ private extension PokitRootFeature {
                         sort: pageable.sort
                     )
                 ).toDomain()
-                await send(.inner(.미분류_페이지네이션_결과(contentList: contentList)), animation: .easeInOut)
+                await send(.inner(.미분류_페이지네이션_결과(contentList: contentList)), animation: .pokitDissolve)
             }
         case .목록조회_갱신용:
             state.domain.pageable.page += 1

--- a/Projects/Feature/FeaturePokit/Sources/PokitRootView.swift
+++ b/Projects/Feature/FeaturePokit/Sources/PokitRootView.swift
@@ -100,12 +100,17 @@ private extension PokitRootView {
         Group {
             if store.folderType == .folder(.포킷) {
                 pokitView
+                    .pokitBlurReplaceTransition(.pokitDissolve)
             } else {
                 unclassifiedView
+                    .pokitBlurReplaceTransition(.pokitDissolve)
             }
         }
         .padding(.top, 20)
         .scrollIndicators(.hidden)
+        .animation(.pokitDissolve, value: store.categories?.elements)
+        .animation(.pokitDissolve, value: store.unclassifiedContents?.elements)
+        .animation(.pokitDissolve, value: store.folderType)
     }
     
     var pokitView: some View {

--- a/Projects/Feature/FeatureRemind/Sources/Remind/RemindFeature.swift
+++ b/Projects/Feature/FeatureRemind/Sources/Remind/RemindFeature.swift
@@ -167,9 +167,9 @@ private extension RemindFeature {
             return .none
         case .remindViewOnAppeared:
             return .run { send in
-                await send(.async(.오늘의_리마인드_조회), animation: .smooth)
-                await send(.async(.읽지않음_컨텐츠_조회), animation: .smooth)
-                await send(.async(.즐겨찾기_링크모음_조회), animation: .smooth)
+                await send(.async(.오늘의_리마인드_조회), animation: .pokitDissolve)
+                await send(.async(.읽지않음_컨텐츠_조회), animation: .pokitDissolve)
+                await send(.async(.즐겨찾기_링크모음_조회), animation: .pokitDissolve)
             }
         }
     }
@@ -202,7 +202,7 @@ private extension RemindFeature {
         case .오늘의_리마인드_조회:
             return .run { send in
                 let contents = try await remindClient.오늘의_리마인드_조회().map { $0.toDomain() }
-                await send(.inner(.오늘의_리마인드_조회(contents: contents)), animation: .smooth)
+                await send(.inner(.오늘의_리마인드_조회(contents: contents)), animation: .pokitDissolve)
             }
         case .읽지않음_컨텐츠_조회:
             return .run { [pageable = state.domain.unreadListPageable] send in
@@ -213,7 +213,7 @@ private extension RemindFeature {
                         sort: pageable.sort
                     )
                 ).toDomain()
-                await send(.inner(.읽지않음_컨텐츠_조회(contentList: contentList)), animation: .smooth)
+                await send(.inner(.읽지않음_컨텐츠_조회(contentList: contentList)), animation: .pokitDissolve)
             }
         case .즐겨찾기_링크모음_조회:
             return .run { [pageable = state.domain.favoriteListPageable] send in
@@ -224,7 +224,7 @@ private extension RemindFeature {
                         sort: pageable.sort
                     )
                 ).toDomain()
-                await send(.inner(.즐겨찾기_링크모음_조회(contentList: contentList)), animation: .smooth)
+                await send(.inner(.즐겨찾기_링크모음_조회(contentList: contentList)), animation: .pokitDissolve)
             }
         case .컨텐츠_삭제(id: let id):
             return .run { [id] send in

--- a/Projects/Feature/FeatureRemind/Sources/Remind/RemindView.swift
+++ b/Projects/Feature/FeatureRemind/Sources/Remind/RemindView.swift
@@ -45,7 +45,7 @@ public extension RemindView {
                         confirmText: "삭제"
                     ) { send(.deleteAlertConfirmTapped(content: content)) }
                 }
-                .task { await send(.remindViewOnAppeared, animation: .smooth).finish() }
+                .task { await send(.remindViewOnAppeared, animation: .pokitDissolve).finish() }
         }
     }
 }

--- a/Projects/Feature/FeatureRemind/Sources/Remind/RemindView.swift
+++ b/Projects/Feature/FeatureRemind/Sources/Remind/RemindView.swift
@@ -83,7 +83,6 @@ extension RemindView {
                             
                             Spacer()
                         }
-                        .padding(.top, 16)
                         .padding(.bottom, 150)
                     }
                 }

--- a/Projects/Feature/FeatureSetting/Sources/Search/PokitSearchFeature.swift
+++ b/Projects/Feature/FeatureSetting/Sources/Search/PokitSearchFeature.swift
@@ -439,7 +439,7 @@ private extension PokitSearchFeature {
                         endDate: endDateString
                     )
                 ).toDomain()
-                await send(.inner(.컨텐츠_목록_갱신(contentList)), animation: .smooth)
+                await send(.inner(.컨텐츠_목록_갱신(contentList)), animation: .pokitDissolve)
             }
         case .최근검색어_갱신:
             guard state.isAutoSaveSearch else { return .none }

--- a/Projects/Feature/FeatureSetting/Sources/Search/PokitSearchView.swift
+++ b/Projects/Feature/FeatureSetting/Sources/Search/PokitSearchView.swift
@@ -129,7 +129,7 @@ private extension PokitSearchView {
                     Text("검색 내역이 없습니다.")
                         .pokitFont(.b3(.r))
                         .foregroundStyle(.pokit(.text(.tertiary)))
-                        .pokitBlurReplaceTransition(.smooth)
+                        .pokitBlurReplaceTransition(.pokitDissolve)
                         .padding(.vertical, 5)
                 } else {
                     recentSearchList
@@ -138,7 +138,7 @@ private extension PokitSearchView {
                 Text("최근 검색 저장 기능이 꺼져있습니다.")
                     .pokitFont(.b3(.r))
                     .foregroundStyle(.pokit(.text(.tertiary)))
-                    .pokitBlurReplaceTransition(.smooth)
+                    .pokitBlurReplaceTransition(.pokitDissolve)
                     .padding(.vertical, 5)
             }
         }
@@ -165,7 +165,7 @@ private extension PokitSearchView {
             .padding(.horizontal, 20)
             .padding(.vertical, 1)
         }
-        .pokitBlurReplaceTransition(.smooth)
+        .pokitBlurReplaceTransition(.pokitDissolve)
     }
     
     var filterToolbar: some View {
@@ -188,7 +188,7 @@ private extension PokitSearchView {
             }
         }
         .padding(.leading, 20)
-        .pokitBlurReplaceTransition(.smooth)
+        .pokitBlurReplaceTransition(.pokitDissolve)
     }
     
     var filterButton: some View {
@@ -220,7 +220,7 @@ private extension PokitSearchView {
                         size: .small,
                         action: { send(.categoryFilterChipTapped(category: category), animation: .pokitSpring) }
                     )
-                    .pokitBlurReplaceTransition(.smooth)
+                    .pokitBlurReplaceTransition(.pokitDissolve)
                 }
             }
         }
@@ -244,7 +244,7 @@ private extension PokitSearchView {
                         size: .small,
                         action: { send(.favoriteChipTapped, animation: .pokitSpring) }
                     )
-                    .pokitBlurReplaceTransition(.smooth)
+                    .pokitBlurReplaceTransition(.pokitDissolve)
                 }
                 
                 if store.unreadFilter {
@@ -254,7 +254,7 @@ private extension PokitSearchView {
                         size: .small,
                         action: { send(.unreadChipTapped, animation: .pokitSpring) }
                     )
-                    .pokitBlurReplaceTransition(.smooth)
+                    .pokitBlurReplaceTransition(.pokitDissolve)
                 }
             }
         }
@@ -268,7 +268,7 @@ private extension PokitSearchView {
             size: .small,
             action: { send(.dateFilterButtonTapped, animation: .pokitSpring) }
         )
-        .pokitBlurReplaceTransition(.smooth)
+        .pokitBlurReplaceTransition(.pokitDissolve)
     }
     
     var resultList: some View {
@@ -276,7 +276,7 @@ private extension PokitSearchView {
             PokitIconLTextLink(
                 store.isResultAscending ? "최신순" : "오래된순",
                 icon: .icon(.align),
-                action: { send(.sortTextLinkTapped, animation: .smooth) }
+                action: { send(.sortTextLinkTapped, animation: .pokitDissolve) }
             )
             .contentTransition(.numericText())
             .padding(.horizontal, 20)

--- a/Projects/Feature/FeatureSetting/Sources/Search/Sheet/FilterBottomFeature.swift
+++ b/Projects/Feature/FeatureSetting/Sources/Search/Sheet/FilterBottomFeature.swift
@@ -224,7 +224,7 @@ private extension FilterBottomFeature {
                     ),
                     true
                 ).toDomain()
-                await send(.inner(.카테고리_목록_갱신(categoryList: categoryList)), animation: .smooth)
+                await send(.inner(.카테고리_목록_갱신(categoryList: categoryList)), animation: .pokitDissolve)
             }
         }
     }

--- a/Projects/Feature/FeatureSetting/Sources/Search/Sheet/FilterBottomSheet.swift
+++ b/Projects/Feature/FeatureSetting/Sources/Search/Sheet/FilterBottomSheet.swift
@@ -147,7 +147,8 @@ private extension FilterBottomSheet {
                 
                 Spacer()
             }
-            .padding(24)
+            .padding(.horizontal, 24)
+            .padding(.vertical, 16)
         }
     }
     

--- a/Projects/Feature/FeatureSetting/Sources/Search/Sheet/FilterBottomSheet.swift
+++ b/Projects/Feature/FeatureSetting/Sources/Search/Sheet/FilterBottomSheet.swift
@@ -75,21 +75,21 @@ private extension FilterBottomSheet {
                 selection: $store.currentType,
                 to: .pokit
             )
-            .matchedGeometryEffectBackground(id: heroEffect)
+            .backgound()
             
             PokitPartTap(
                 "모아보기",
                 selection: $store.currentType,
                 to: .contentType
             )
-            .matchedGeometryEffectBackground(id: heroEffect)
+            .backgound()
             
             PokitPartTap(
                 "기간",
                 selection: $store.currentType,
                 to: .date
             )
-            .matchedGeometryEffectBackground(id: heroEffect)
+            .backgound()
         }
     }
     
@@ -160,7 +160,7 @@ private extension FilterBottomSheet {
                         size: .small,
                         action: { send(.pokitChipTapped(category), animation: .pokitSpring) }
                     )
-                    .pokitBlurReplaceTransition(.smooth)
+                    .pokitBlurReplaceTransition(.pokitDissolve)
                 }
                 
                 if store.isFavorite {
@@ -170,7 +170,7 @@ private extension FilterBottomSheet {
                         size: .small,
                         action: { send(.favoriteChipTapped, animation: .pokitSpring) }
                     )
-                    .pokitBlurReplaceTransition(.smooth)
+                    .pokitBlurReplaceTransition(.pokitDissolve)
                 }
                 
                 if store.isUnread {
@@ -180,7 +180,7 @@ private extension FilterBottomSheet {
                         size: .small,
                         action: { send(.unreadChipTapped, animation: .pokitSpring) }
                     )
-                    .pokitBlurReplaceTransition(.smooth)
+                    .pokitBlurReplaceTransition(.pokitDissolve)
                 }
                 
                 if store.dateSelected {
@@ -191,7 +191,7 @@ private extension FilterBottomSheet {
                         size: .small,
                         action: { send(.dateChipTapped, animation: .pokitSpring) }
                     )
-                    .pokitBlurReplaceTransition(.smooth)
+                    .pokitBlurReplaceTransition(.pokitDissolve)
                     .contentTransition(.numericText())
                 }
             }

--- a/Projects/Feature/FeatureSetting/Sources/Search/Sheet/FilterBottomSheet.swift
+++ b/Projects/Feature/FeatureSetting/Sources/Search/Sheet/FilterBottomSheet.swift
@@ -26,10 +26,11 @@ public struct FilterBottomSheet: View {
 public extension FilterBottomSheet {
     var body: some View {
         WithPerceptionTracking {
-            VStack(spacing: 4) {
+            VStack(spacing: 0) {
                 tabs
                     .padding(.horizontal, 20)
                     .padding(.top, 36)
+                    .padding(.bottom, 16)
                 
                 switch store.currentType {
                 case .pokit:

--- a/Projects/Feature/FeatureSetting/Sources/Search/Sheet/FilterBottomSheet.swift
+++ b/Projects/Feature/FeatureSetting/Sources/Search/Sheet/FilterBottomSheet.swift
@@ -137,7 +137,7 @@ private extension FilterBottomSheet {
                     baseState: .default,
                     selectedState: .filled,
                     isSelected: isSelected,
-                    shape: .round
+                    shape: .rectangle
                 )
                 
                 Text(title)


### PR DESCRIPTION
## #️⃣연관된 이슈

> #92 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- PokitCard 아이콘 크기 84x84로 수정
- 포킷 정렬 애니메이션 수정(반영 못할 수 도 있음)
- mainTab 추가하기 버튼 60x60로 수정(반영 못할 수 도 있음)
- PokitCard 포킷명 아이콘 사이 간격 4로 수정
- 빈 리스트가 아닌데도 empty 화면이 뜨고 사라지는 문제 수정
- 포킷 삭제하기 메세지 수정
- 컨텐츠 상세 하단 높이 버그 수정
- 컨텐츠 상세 즐겨찾기 해제 아이콘 fill로 변경
- 컨텐츠 상세 메모에 텍스트가 없을 경우 placeholder "메모를 작성해보세요." 추가
- 컨텐츠 상세에서 링크 제목 추출 실패 시 컨텐츠 제목으로 대체
- 컨텐츠 검색 필터에서 필터 종류 전환 효과 빠르게 수정
- pokitBlurTransition 애니메이션 속도 빠르게 수정
- 컨텐츠 검색 필터에서 즐겨찾기, 안읽음 checkbox rectangle로 수정
- 컨텐츠 검색 필터에서 모아보기 리스트 top 패딩 16으로 수정
- 컨텐츠 검색 필터에서 즐겨찾기, 안읽음 항목 상하 여백 16으로 수정
- 컨텐츠 검색 필터에서 포킷 리스트 top 패딩 16으로 수정
- 링크 추가/수정에서 리마인드 switch radio 애니메이션 수정
- 링크 추가/수정에서 url 파싱 completion 및 저장 예외 처리 추가
- PokitList presentationDetents medium으로 제한
- PokitList height 74로 수정
- 포킷 수정/추가에서 포킷 이미지 선텍에서 이미지 크기 72x72로 수정
- 포킷 수정/추가에서 포킷 이미지 선텍에서 하단 간격 28로 수정
- 리마인드 상단 패딩 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
- 모든 픽셀들이 figma와 2px씩 차이가 나는데 왜 그런지 모르겠습니다.. 디자이너들은 수정 못해도 괜찮다고 하는데 이유라도 알고싶어요..
- pm qa와 겹치는 사항들은 반영하지 않았습니다.

close 이슈번호
