### PR TITLE
1.0.0에서 발견한 버그 수정

### DIFF
--- a/Projects/App/Sources/Intro/IntroFeature.swift
+++ b/Projects/App/Sources/Intro/IntroFeature.swift
@@ -16,7 +16,7 @@ public struct IntroFeature {
     @ObservableState
     public enum State {
         case splash(SplashFeature.State = .init())
-        case login(LoginRootFeature.State = .init())
+        case login(LoginRootFeature.State = .login(.init()))
         public init() { self = .splash() }
     }
     /// - Action
@@ -42,7 +42,7 @@ public struct IntroFeature {
         case .splash(let splashAction):
             return splashDelegate(splashAction, state: &state)
             
-        case .login(.delegate(.dismissLoginRootView)):
+        case .login(.delegate(.로그인_루트_닫기)):
             return .run { send in await send(.delegate(.moveToTab), animation: .smooth) }
             
         case .delegate, .login:

--- a/Projects/App/Sources/MainTab/MainTabPath.swift
+++ b/Projects/App/Sources/MainTab/MainTabPath.swift
@@ -135,8 +135,9 @@ public extension MainTabFeature {
                  let .path(.element(_, action: .알림함(.delegate(.moveToContentEdit(id))))):
                 return .run { send in await send(.inner(.링크추가및수정이동(contentId: id))) }
             
-            /// - 컨텐츠 상세보기 닫힘
-            case .contentDetail(.dismiss):
+            /// - 컨텐츠 상세보기 내부 액션 실행
+            case .contentDetail(.presented(.delegate(.즐겨찾기_갱신_완료))),
+                 .contentDetail(.presented(.delegate(.컨텐츠_조회_완료))):
                 guard let stackElementId = state.path.ids.last,
                       let lastPath = state.path.last else {
                     switch state.selectedTab {

--- a/Projects/CoreKit/Sources/Data/DTO/Auth/WithdrawRequest.swift
+++ b/Projects/CoreKit/Sources/Data/DTO/Auth/WithdrawRequest.swift
@@ -9,11 +9,9 @@ import Foundation
 /// 회원탈퇴 API Request
 /// 📌 회원탈퇴는 Response가 없음
 public struct WithdrawRequest: Encodable {
-    public let refreshToken: String
     public let authPlatform: String
     
-    public init(refreshToken: String, authPlatform: String) {
-        self.refreshToken = refreshToken
+    public init(authPlatform: String) {
         self.authPlatform = authPlatform
     }
 }

--- a/Projects/DSKit/Sources/Components/PokitShareSheet.swift
+++ b/Projects/DSKit/Sources/Components/PokitShareSheet.swift
@@ -9,11 +9,11 @@ import SwiftUI
 
 public struct PokitShareSheet: UIViewControllerRepresentable {
     private var items: [Any]
-    private var completion: ((_ completed: Bool) -> Void)?
+    private var completion: (() -> Void)?
     
     public init(
         items: [Any],
-        completion: ((_: Bool) -> Void)?
+        completion: (() -> Void)?
     ) {
         self.items = items
         self.completion = completion
@@ -24,8 +24,8 @@ public struct PokitShareSheet: UIViewControllerRepresentable {
             activityItems: items,
             applicationActivities: nil
         )
-        controller.completionWithItemsHandler = { _, completed, _, _ in
-            completion?(completed)
+        controller.completionWithItemsHandler = { _, _, _, _ in
+            completion?()
         }
         return controller
     }

--- a/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailFeature.swift
+++ b/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailFeature.swift
@@ -100,7 +100,7 @@ public struct CategoryDetailFeature {
             case dismiss
             case onAppear
             case pagenation
-            case 링크_공유_완료(completed: Bool)
+            case 링크_공유_완료
         }
         
         public enum InnerAction: Equatable {
@@ -219,7 +219,7 @@ private extension CategoryDetailFeature {
             }
         case .pagenation:
             return .run { send in await send(.async(.pagenation_네트워크)) }
-        case .링크_공유_완료(completed: let completed):
+        case .링크_공유_완료:
             state.shareSheetItem = nil
             return .none
         }

--- a/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailFeature.swift
+++ b/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailFeature.swift
@@ -63,6 +63,7 @@ public struct CategoryDetailFeature {
         }
         var kebobSelectedType: PokitDeleteBottomSheet.SheetType?
         var selectedContentItem: BaseContentItem?
+        var shareSheetItem: BaseContentItem? = nil
         /// sheet Presented
         var isCategorySheetPresented: Bool = false
         var isCategorySelectSheetPresented: Bool = false
@@ -99,6 +100,7 @@ public struct CategoryDetailFeature {
             case dismiss
             case onAppear
             case pagenation
+            case 링크_공유_완료(completed: Bool)
         }
         
         public enum InnerAction: Equatable {
@@ -217,6 +219,9 @@ private extension CategoryDetailFeature {
             }
         case .pagenation:
             return .run { send in await send(.async(.pagenation_네트워크)) }
+        case .링크_공유_완료(completed: let completed):
+            state.shareSheetItem = nil
+            return .none
         }
     }
     
@@ -304,13 +309,20 @@ private extension CategoryDetailFeature {
         case .categoryBottomSheet(let delegateAction):
             switch delegateAction {
             case .shareCellButtonTapped:
-                kakaoShareClient.카테고리_카카오톡_공유(
-                    CategoryKaKaoShareModel(
-                        categoryName: state.domain.category.categoryName,
-                        categoryId: state.domain.category.id,
-                        imageURL: state.domain.category.categoryImage.imageURL
+                switch state.kebobSelectedType {
+                case .링크삭제:
+                    state.shareSheetItem = state.selectedContentItem
+                case .포킷삭제:
+                    kakaoShareClient.카테고리_카카오톡_공유(
+                        CategoryKaKaoShareModel(
+                            categoryName: state.domain.category.categoryName,
+                            categoryId: state.domain.category.id,
+                            imageURL: state.domain.category.categoryImage.imageURL
+                        )
                     )
-                )
+                default: return .none
+                }
+                
                 state.isCategorySheetPresented = false
                 return .none
                 

--- a/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailView.swift
+++ b/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailView.swift
@@ -41,6 +41,15 @@ public extension CategoryDetailView {
                     delegateSend: { store.send(.scope(.categoryBottomSheet($0))) }
                 )
             }
+            .sheet(item: $store.shareSheetItem) { content in
+                if let shareURL = URL(string: content.data) {
+                    PokitShareSheet(
+                        items: [shareURL],
+                        completion: { send(.링크_공유_완료(completed: $0)) }
+                    )
+                    .presentationDetents([.medium, .large])
+                }
+            }
             .sheet(isPresented: $store.isCategorySelectSheetPresented) {
                 if let categories = store.categories {
                     PokitCategorySheet(

--- a/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailView.swift
+++ b/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailView.swift
@@ -45,7 +45,7 @@ public extension CategoryDetailView {
                 if let shareURL = URL(string: content.data) {
                     PokitShareSheet(
                         items: [shareURL],
-                        completion: { send(.링크_공유_완료(completed: $0)) }
+                        completion: { send(.링크_공유_완료) }
                     )
                     .presentationDetents([.medium, .large])
                 }

--- a/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailFeature.swift
+++ b/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailFeature.swift
@@ -70,7 +70,7 @@ public struct ContentDetailFeature {
             case favoriteButtonTapped
             case alertCancelButtonTapped
 
-            case 링크_공유_완료(completed: Bool)
+            case 링크_공유_완료
         }
 
         public enum InnerAction: Equatable {
@@ -176,7 +176,7 @@ private extension ContentDetailFeature {
                     await send(.async(.즐겨찾기(id: content.id)))
                 }
             }
-        case .링크_공유_완료(completed: let completed):
+        case .링크_공유_완료:
             state.showShareSheet = false
             return .none
         case .alertCancelButtonTapped:

--- a/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailFeature.swift
+++ b/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailFeature.swift
@@ -177,7 +177,7 @@ private extension ContentDetailFeature {
                 }
             }
         case .링크_공유_완료(completed: let completed):
-            state.showShareSheet = !completed
+            state.showShareSheet = false
             return .none
         case .alertCancelButtonTapped:
             state.showAlert = false

--- a/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailFeature.swift
+++ b/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailFeature.swift
@@ -94,6 +94,8 @@ public struct ContentDetailFeature {
 
         public enum DelegateAction: Equatable {
             case editButtonTapped(contentId: Int)
+            case 즐겨찾기_갱신_완료
+            case 컨텐츠_조회_완료
         }
     }
 
@@ -216,10 +218,13 @@ private extension ContentDetailFeature {
             return .none
         case .컨텐츠_상세_조회(content: let content):
             state.domain.content = content
-            return .send(.inner(.parsingURL))
+            return .run { send in
+                await send(.delegate(.컨텐츠_조회_완료))
+                await send(.inner(.parsingURL))
+            }
         case .즐겨찾기_갱신(let favorite):
             state.domain.content?.favorites = favorite
-            return .none
+            return .send(.delegate(.즐겨찾기_갱신_완료))
         case .링크미리보기_presented:
             state.showLinkPreview = true
             return .none

--- a/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailView.swift
+++ b/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailView.swift
@@ -62,7 +62,7 @@ public extension ContentDetailView {
                    let shareURL = URL(string: content.data) {
                     PokitShareSheet(
                         items: [shareURL],
-                        completion: { send(.링크_공유_완료(completed: $0)) }
+                        completion: { send(.링크_공유_완료) }
                     )
                     .presentationDetents([.medium, .large])
                 }

--- a/Projects/Feature/FeatureContentList/Sources/ContentList/ContentListFeature.swift
+++ b/Projects/Feature/FeatureContentList/Sources/ContentList/ContentListFeature.swift
@@ -194,7 +194,6 @@ private extension ContentListFeature {
         case .pagenation:
             return .run { send in await send(.async(.pagenation_네트워크)) }
         case .링크_공유_완료(completed: let completed):
-            guard completed else { return .none }
             state.shareSheetItem = nil
             return .none
         }

--- a/Projects/Feature/FeatureContentList/Sources/ContentList/ContentListFeature.swift
+++ b/Projects/Feature/FeatureContentList/Sources/ContentList/ContentListFeature.swift
@@ -77,7 +77,7 @@ public struct ContentListFeature {
             case contentListViewOnAppeared
             case pagenation
             
-            case 링크_공유_완료(completed: Bool)
+            case 링크_공유_완료
         }
 
         public enum InnerAction: Equatable {
@@ -193,7 +193,7 @@ private extension ContentListFeature {
 
         case .pagenation:
             return .run { send in await send(.async(.pagenation_네트워크)) }
-        case .링크_공유_완료(completed: let completed):
+        case .링크_공유_완료:
             state.shareSheetItem = nil
             return .none
         }

--- a/Projects/Feature/FeatureContentList/Sources/ContentList/ContentListView.swift
+++ b/Projects/Feature/FeatureContentList/Sources/ContentList/ContentListView.swift
@@ -46,7 +46,7 @@ public extension ContentListView {
                 if let shareURL = URL(string: content.data) {
                     PokitShareSheet(
                         items: [shareURL],
-                        completion: { send(.링크_공유_완료(completed: $0)) }
+                        completion: { send(.링크_공유_완료) }
                     )
                     .presentationDetents([.medium, .large])
                 }

--- a/Projects/Feature/FeatureLogin/Sources/Login/LoginFeature.swift
+++ b/Projects/Feature/FeatureLogin/Sources/Login/LoginFeature.swift
@@ -1,0 +1,250 @@
+//
+//  SignUpNavigationStackFeature.swift
+//  Feature
+//
+//  Created by 김도형 on 7/7/24.
+
+import ComposableArchitecture
+import CoreKit
+import Util
+
+@Reducer
+public struct LoginFeature {
+    /// - Dependency
+    @Dependency(\.dismiss) var dismiss
+    @Dependency(\.socialLogin) var socialLogin
+    @Dependency(\.authClient) var authClient
+    @Dependency(\.userClient) var userClient
+    @Dependency(\.userDefaults) var userDefaults
+    @Dependency(\.keychain) var keychain
+    /// - State
+    @ObservableState
+    public struct State {
+        var path = StackState<Path.State>()
+
+        var nickName: String?
+        var interests: [String]?
+        
+        public init() {}
+    }
+    /// - Action
+    public enum Action: FeatureAction, ViewAction {
+        case view(View)
+        case inner(InnerAction)
+        case async(AsyncAction)
+        case scope(ScopeAction)
+        case delegate(DelegateAction)
+        case path(StackActionOf<Path>)
+        
+        @CasePathable
+        public enum View: Equatable {
+            /// - Button Tapped
+            case appleLoginButtonTapped
+            case googleLoginButtonTapped
+        }
+        public enum InnerAction: Equatable {
+            case pushAgreeToTermsView
+            case pushRegisterNicknameView
+            case pushSelectFieldView(nickname: String)
+            case pushSignUpDoneView
+            case 애플로그인(SocialLoginInfo)
+            case 구글로그인(SocialLoginInfo)
+            case 로그인_이후_화면이동(isRegistered: Bool)
+        }
+        public enum AsyncAction: Equatable {
+            case 회원가입
+            case 로그인(SocialLoginInfo)
+        }
+        public enum ScopeAction {
+            case agreeToTerms(AgreeToTermsFeature.Action.DelegateAction)
+            case registerNickname(RegisterNicknameFeature.Action.DelegateAction)
+            case selectField(SelectFieldFeature.Action.DelegateAction)
+        }
+        public enum DelegateAction: Equatable {
+            case dismissLoginRootView
+            case 회원가입_완료_화면_이동
+        }
+    }
+    /// initiallizer
+    public init() {}
+    /// - Reducer Core
+    private func core(into state: inout State, action: Action) -> Effect<Action> {
+        switch action {
+            /// - View
+        case .view(let viewAction):
+            return handleViewAction(viewAction, state: &state)
+            /// - Inner
+        case .inner(let innerAction):
+            return handleInnerAction(innerAction, state: &state)
+            /// - Async
+        case .async(let asyncAction):
+            return handleAsyncAction(asyncAction, state: &state)
+            /// - Scope
+        case .scope(let scopeAction):
+            return handleScopeAction(scopeAction, state: &state)
+            /// - Delegate
+        case .delegate(let delegateAction):
+            return handleDelegateAction(delegateAction, state: &state)
+        case .path(let pathAction):
+            return handlePathAction(pathAction, state: &state)
+        }
+    }
+    /// - Reducer body
+    public var body: some ReducerOf<Self> {
+        Reduce(self.core)
+            .forEach(\.path, action: \.path)
+    }
+}
+//MARK: - FeatureAction Effect
+private extension LoginFeature {
+    /// - View Effect
+    func handleViewAction(_ action: Action.View, state: inout State) -> Effect<Action> {
+        switch action {
+        case .appleLoginButtonTapped:
+            return .run { send in
+                let response = try await socialLogin.appleLogin()
+                await send(.async(.로그인(response)))
+            }
+            
+        case .googleLoginButtonTapped:
+            return .run { send in
+                let response = try await socialLogin.googleLogin()
+                await send(.async(.로그인(response)))
+            }
+        }
+    }
+    /// - Inner Effect
+    func handleInnerAction(_ action: Action.InnerAction, state: inout State) -> Effect<Action> {
+        switch action {
+        case .pushAgreeToTermsView:
+            state.path.append(.agreeToTerms(AgreeToTermsFeature.State()))
+            return .none
+        case .pushRegisterNicknameView:
+            state.path.append(.registerNickname(RegisterNicknameFeature.State()))
+            return .none
+        case .pushSelectFieldView(let nickname):
+            state.path.append(.selecteField(SelectFieldFeature.State(nickname: nickname)))
+            return .none
+        case .pushSignUpDoneView:
+            return .send(.delegate(.회원가입_완료_화면_이동))
+        case let .애플로그인(response):
+            return .run { send in
+                guard let idToken = response.idToken else { return }
+                guard let authCode = response.authCode else { return }
+                guard let jwt = response.jwt else { return }
+                
+                let platform = response.provider.description
+                let request = SignInRequest(authPlatform: platform, idToken: idToken)
+                let tokenResponse = try await authClient.로그인(request)
+                
+                /// [1]. UserDefaults에 최근 로그인한 애플로그인 `정보`저장
+                await userDefaults.setString(platform, .authPlatform)
+                await userDefaults.setString(authCode, .authCode)
+                await userDefaults.setString(jwt, .jwt)
+                /// [2]. Keychain에 `access`, `refresh` 저장
+                keychain.save(.accessToken, tokenResponse.accessToken)
+                keychain.save(.refreshToken, tokenResponse.refreshToken)
+                
+                let appleTokenRequest = AppleTokenRequest(authCode: authCode, jwt: jwt)
+                let appleTokenResponse = try await authClient.apple(appleTokenRequest)
+                keychain.save(.serverRefresh, appleTokenResponse.refresh_token)
+                
+                await send(.inner(.로그인_이후_화면이동(isRegistered: tokenResponse.isRegistered)))
+            }
+        case let .구글로그인(response):
+            return .run { send in
+                guard let idToken = response.idToken else { return }
+                let platform = response.provider.description
+                let request = SignInRequest(authPlatform: platform, idToken: idToken)
+                let tokenResponse = try await authClient.로그인(request)
+                
+                /// [1]. UserDefaults에 최근 로그인한 소셜로그인 `타입`저장
+                await userDefaults.setString(platform, .authPlatform)
+                /// [2]. Keychain에 `access`, `refresh` 저장
+                keychain.save(.accessToken, tokenResponse.accessToken)
+                keychain.save(.refreshToken, tokenResponse.refreshToken)
+                keychain.save(.serverRefresh, response.serverRefreshToken)
+                
+                await send(.inner(.로그인_이후_화면이동(isRegistered: tokenResponse.isRegistered)))
+            }
+        case let .로그인_이후_화면이동(isRegistered):
+            /// [3]. 이미 회원가입했던 유저라면 `메인`이동
+            if isRegistered {
+                return .run { send in await send(.delegate(.dismissLoginRootView)) }
+            } else {
+                return .run { send in await send(.inner(.pushAgreeToTermsView)) }
+            }
+        }
+    }
+    /// - Async Effect
+    func handleAsyncAction(_ action: Action.AsyncAction, state: inout State) -> Effect<Action> {
+        switch action {
+        case .회원가입:
+            return .run { [nickName = state.nickName, interests = state.interests] send in
+                guard let nickName else { return }
+                guard let interests else { return }
+                let signUpRequest = SignupRequest(nickName: nickName, interests: interests)
+                let _ = try await userClient.회원등록(signUpRequest)
+                
+                await send(.inner(.pushSignUpDoneView))
+            }
+        
+        case .로그인(let response):
+            switch response.provider {
+            case .apple:
+                return .run { send in await send(.inner(.애플로그인(response))) }
+            case .google:
+                return .run { send in await send(.inner(.구글로그인(response))) }
+            }
+        }
+    }
+    /// - Scope Effect
+    func handleScopeAction(_ action: Action.ScopeAction, state: inout State) -> Effect<Action> {
+        switch action {
+        case .agreeToTerms(let delegate):
+            switch delegate {
+            case .pushRegisterNicknameView:
+                return .send(.inner(.pushRegisterNicknameView))
+            }
+        case .registerNickname(let delegate):
+            switch delegate {
+            case .pushSelectFieldView(let nickname):
+                state.nickName = nickname
+                return .send(.inner(.pushSelectFieldView(nickname: nickname)))
+            }
+        case .selectField(let delegate):
+            switch delegate {
+            case let .pushSignUpDoneView(interests):
+                state.interests = interests
+                return .send(.async(.회원가입))
+            }
+        }
+    }
+    /// - Delegate Effect
+    func handleDelegateAction(_ action: Action.DelegateAction, state: inout State) -> Effect<Action> {
+        return .none
+    }
+
+    func handlePathAction(_ action: StackActionOf<Path>, state: inout State) -> Effect<Action> {
+        switch action {
+        case .element(id: _, action: .agreeToTerms(.delegate(let delegate))):
+            return .send(.scope(.agreeToTerms(delegate)))
+        case .element(id: _, action: .registerNickname(.delegate(let delegate))):
+            return .send(.scope(.registerNickname(delegate)))
+        case .element(id: _, action: .selecteField(.delegate(let delegate))):
+            return .send(.scope(.selectField(delegate)))
+        case .element, .popFrom, .push:
+            return .none
+        }
+    }
+}
+
+//MARK: - Path
+extension LoginFeature {
+    @Reducer
+    public enum Path {
+        case agreeToTerms(AgreeToTermsFeature)
+        case registerNickname(RegisterNicknameFeature)
+        case selecteField(SelectFieldFeature)
+    }
+}

--- a/Projects/Feature/FeatureLogin/Sources/Login/LoginView.swift
+++ b/Projects/Feature/FeatureLogin/Sources/Login/LoginView.swift
@@ -1,0 +1,171 @@
+//
+//  SignUpNavigationStackView.swift
+//  Feature
+//
+//  Created by 김도형 on 7/7/24.
+
+import ComposableArchitecture
+import SwiftUI
+
+import DSKit
+
+@ViewAction(for: LoginFeature.self)
+public struct LoginView: View {
+    /// - Properties
+    @Perception.Bindable
+    public var store: StoreOf<LoginFeature>
+    /// - Initializer
+    public init(store: StoreOf<LoginFeature>) {
+        self.store = store
+    }
+}
+//MARK: - View
+public extension LoginView {
+    var body: some View {
+        WithPerceptionTracking {
+            NavigationStack(path: $store.scope(state: \.path, action: \.path)) {
+                WithPerceptionTracking {
+                    VStack(spacing: 8) {
+                        logo
+                        
+                        Spacer()
+                        
+                        appleLoginButton
+                            .pokitMaxWidth()
+                        
+                        googleLoginButton
+                            .pokitMaxWidth()
+                    }
+                    .padding(.horizontal, 20)
+                    .padding(.bottom, 36)
+                    .background(.pokit(.bg(.base)))
+                    .ignoresSafeArea(edges: .bottom)
+                    .navigationBarBackButtonHidden()
+                }
+            } destination: { path in
+                WithPerceptionTracking {
+                    switch path.case {
+                    case .agreeToTerms(let store):
+                        AgreeToTermsView(store: store)
+                    case .registerNickname(let store):
+                        RegisterNicknameView(store: store)
+                    case .selecteField(let store):
+                        SelectFieldView(store: store)
+                    }
+                }
+            }
+        }
+    }
+}
+//MARK: - Configure View
+extension LoginView {
+    private var logo: some View {
+        HStack {
+            Spacer()
+            
+            VStack(spacing: 24) {
+                Image(.logo(.pokit))
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(height: 72)
+                    .foregroundStyle(.pokit(.icon(.brand)))
+                
+                Text("다양한 링크들을 한 곳에")
+                    .pokitFont(.b1(.b))
+                    .foregroundStyle(.pokit(.text(.secondary)))
+            }
+            
+            Spacer()
+        }
+        .padding(.top, 254)
+    }
+    
+    private var appleLoginButton: some View {
+        Button {
+            send(.appleLoginButtonTapped)
+        } label: {
+            appleLoginButtonLabel
+        }
+    }
+    
+    private var appleLoginButtonLabel: some View {
+        VStack {
+            Spacer()
+            
+            HStack(spacing: 12) {
+                Spacer()
+                
+                Image(systemName: "apple.logo")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 24, height: 24)
+                    .foregroundColor(.pokit(.icon(.inverseWh)))
+                
+                Text("Apple로 계속하기")
+                    .pokitFont(.l1(.r))
+                    .foregroundStyle(.pokit(.text(.inverseWh)))
+                
+                Spacer()
+            }
+            
+            Spacer()
+        }
+        .background {
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(.black)
+                .overlay {
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .stroke(.pokit(.border(.secondary)), lineWidth: 1)
+                }
+        }
+        .frame(height: 50)
+    }
+    
+    private var googleLoginButton: some View {
+        Button {
+            send(.googleLoginButtonTapped)
+        } label: {
+            googleLoginButtonLabel
+        }
+    }
+    
+    private var googleLoginButtonLabel: some View {
+        VStack {
+            Spacer()
+            
+            HStack(spacing: 12) {
+                Spacer()
+                
+                Image(.icon(.google))
+                    .resizable()
+                    .frame(width: 24, height: 24)
+                
+                Text("Google로 계속하기")
+                    .pokitFont(.l1(.r))
+                    .foregroundStyle(.pokit(.text(.primary)))
+                
+                Spacer()
+            }
+            
+            Spacer()
+        }
+        .background {
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(.pokit(.bg(.base)))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .stroke(.pokit(.border(.secondary)), lineWidth: 1)
+                }
+        }
+        .frame(height: 50)
+    }
+}
+//MARK: - Preview
+#Preview {
+    LoginView(
+        store: Store(
+            initialState: .init(),
+            reducer: { LoginFeature() }
+        )
+    )
+}

--- a/Projects/Feature/FeatureLogin/Sources/LoginRoot/LoginRootFeature.swift
+++ b/Projects/Feature/FeatureLogin/Sources/LoginRoot/LoginRootFeature.swift
@@ -1,259 +1,59 @@
 //
-//  SignUpNavigationStackFeature.swift
+//  LoginRootFeature.swift
 //  Feature
 //
-//  Created by 김도형 on 7/7/24.
+//  Created by 김도형 on 9/7/24.
 
 import ComposableArchitecture
-import CoreKit
 import Util
 
 @Reducer
 public struct LoginRootFeature {
     /// - Dependency
-    @Dependency(\.dismiss) var dismiss
-    @Dependency(\.socialLogin) var socialLogin
-    @Dependency(\.authClient) var authClient
-    @Dependency(\.userClient) var userClient
-    @Dependency(\.userDefaults) var userDefaults
-    @Dependency(\.keychain) var keychain
+
     /// - State
     @ObservableState
-    public struct State {
-        var path = StackState<Path.State>()
-
-        var nickName: String?
-        var interests: [String]?
-        
-        public init() {}
+    public enum State {
+        case login(LoginFeature.State)
+        case signUpDone(SignUpDoneFeature.State)
     }
+    
     /// - Action
-    public enum Action: FeatureAction, ViewAction {
-        case view(View)
-        case inner(InnerAction)
-        case async(AsyncAction)
-        case scope(ScopeAction)
+    public enum Action {
+        case login(LoginFeature.Action)
+        case signUpDone(SignUpDoneFeature.Action)
         case delegate(DelegateAction)
-        case path(StackActionOf<Path>)
-        
-        @CasePathable
-        public enum View: Equatable {
-            /// - Button Tapped
-            case appleLoginButtonTapped
-            case googleLoginButtonTapped
-        }
-        public enum InnerAction: Equatable {
-            case pushAgreeToTermsView
-            case pushRegisterNicknameView
-            case pushSelectFieldView(nickname: String)
-            case pushSignUpDoneView
-            case 애플로그인(SocialLoginInfo)
-            case 구글로그인(SocialLoginInfo)
-            case 로그인_이후_화면이동(isRegistered: Bool)
-        }
-        public enum AsyncAction: Equatable {
-            case 회원가입
-            case 로그인(SocialLoginInfo)
-        }
-        public enum ScopeAction {
-            case agreeToTerms(AgreeToTermsFeature.Action.DelegateAction)
-            case registerNickname(RegisterNicknameFeature.Action.DelegateAction)
-            case selectField(SelectFieldFeature.Action.DelegateAction)
-            case signUpDone(SignUpDoneFeature.Action.DelegateAction)
-        }
-        public enum DelegateAction: Equatable {
-            case dismissLoginRootView
-        }
     }
-    /// initiallizer
+    
+    public enum DelegateAction {
+        case 로그인_루트_닫기
+    }
+    
+    /// - Initiallizer
     public init() {}
+
     /// - Reducer Core
     private func core(into state: inout State, action: Action) -> Effect<Action> {
         switch action {
-            /// - View
-        case .view(let viewAction):
-            return handleViewAction(viewAction, state: &state)
-            /// - Inner
-        case .inner(let innerAction):
-            return handleInnerAction(innerAction, state: &state)
-            /// - Async
-        case .async(let asyncAction):
-            return handleAsyncAction(asyncAction, state: &state)
-            /// - Scope
-        case .scope(let scopeAction):
-            return handleScopeAction(scopeAction, state: &state)
-            /// - Delegate
-        case .delegate(let delegateAction):
-            return handleDelegateAction(delegateAction, state: &state)
-        case .path(let pathAction):
-            return handlePathAction(pathAction, state: &state)
+        case .login(.delegate(.회원가입_완료_화면_이동)):
+            state = .signUpDone(.init())
+            return .none
+        case .login(.delegate(.dismissLoginRootView)),
+             .signUpDone(.delegate(.dismissLoginRootView)):
+            return .send(.delegate(.로그인_루트_닫기))
+        case .login, .signUpDone, .delegate:
+            return .none
         }
     }
+    
     /// - Reducer body
     public var body: some ReducerOf<Self> {
         Reduce(self.core)
-            .forEach(\.path, action: \.path)
-    }
-}
-//MARK: - FeatureAction Effect
-private extension LoginRootFeature {
-    /// - View Effect
-    func handleViewAction(_ action: Action.View, state: inout State) -> Effect<Action> {
-        switch action {
-        case .appleLoginButtonTapped:
-            return .run { send in
-                let response = try await socialLogin.appleLogin()
-                await send(.async(.로그인(response)))
+            .ifCaseLet(\.login, action: \.login) {
+                LoginFeature()
             }
-            
-        case .googleLoginButtonTapped:
-            return .run { send in
-                let response = try await socialLogin.googleLogin()
-                await send(.async(.로그인(response)))
+            .ifCaseLet(\.signUpDone, action: \.signUpDone) {
+                SignUpDoneFeature()
             }
-        }
-    }
-    /// - Inner Effect
-    func handleInnerAction(_ action: Action.InnerAction, state: inout State) -> Effect<Action> {
-        switch action {
-        case .pushAgreeToTermsView:
-            state.path.append(.agreeToTerms(AgreeToTermsFeature.State()))
-            return .none
-        case .pushRegisterNicknameView:
-            state.path.append(.registerNickname(RegisterNicknameFeature.State()))
-            return .none
-        case .pushSelectFieldView(let nickname):
-            state.path.append(.selecteField(SelectFieldFeature.State(nickname: nickname)))
-            return .none
-        case .pushSignUpDoneView:
-            state.path.append(.signUpDone(SignUpDoneFeature.State()))
-            return .none
-        case let .애플로그인(response):
-            return .run { send in
-                guard let idToken = response.idToken else { return }
-                guard let authCode = response.authCode else { return }
-                guard let jwt = response.jwt else { return }
-                
-                let platform = response.provider.description
-                let request = SignInRequest(authPlatform: platform, idToken: idToken)
-                let tokenResponse = try await authClient.로그인(request)
-                
-                /// [1]. UserDefaults에 최근 로그인한 애플로그인 `정보`저장
-                await userDefaults.setString(platform, .authPlatform)
-                await userDefaults.setString(authCode, .authCode)
-                await userDefaults.setString(jwt, .jwt)
-                /// [2]. Keychain에 `access`, `refresh` 저장
-                keychain.save(.accessToken, tokenResponse.accessToken)
-                keychain.save(.refreshToken, tokenResponse.refreshToken)
-                
-                let appleTokenRequest = AppleTokenRequest(authCode: authCode, jwt: jwt)
-                let appleTokenResponse = try await authClient.apple(appleTokenRequest)
-                keychain.save(.serverRefresh, appleTokenResponse.refresh_token)
-                
-                await send(.inner(.로그인_이후_화면이동(isRegistered: tokenResponse.isRegistered)))
-            }
-        case let .구글로그인(response):
-            return .run { send in
-                guard let idToken = response.idToken else { return }
-                let platform = response.provider.description
-                let request = SignInRequest(authPlatform: platform, idToken: idToken)
-                let tokenResponse = try await authClient.로그인(request)
-                
-                /// [1]. UserDefaults에 최근 로그인한 소셜로그인 `타입`저장
-                await userDefaults.setString(platform, .authPlatform)
-                /// [2]. Keychain에 `access`, `refresh` 저장
-                keychain.save(.accessToken, tokenResponse.accessToken)
-                keychain.save(.refreshToken, tokenResponse.refreshToken)
-                keychain.save(.serverRefresh, response.serverRefreshToken)
-                
-                await send(.inner(.로그인_이후_화면이동(isRegistered: tokenResponse.isRegistered)))
-            }
-        case let .로그인_이후_화면이동(isRegistered):
-            /// [3]. 이미 회원가입했던 유저라면 `메인`이동
-            if isRegistered {
-                return .run { send in await send(.delegate(.dismissLoginRootView)) }
-            } else {
-                return .run { send in await send(.inner(.pushAgreeToTermsView)) }
-            }
-        }
-    }
-    /// - Async Effect
-    func handleAsyncAction(_ action: Action.AsyncAction, state: inout State) -> Effect<Action> {
-        switch action {
-        case .회원가입:
-            return .run { [nickName = state.nickName, interests = state.interests] send in
-                guard let nickName else { return }
-                guard let interests else { return }
-                let signUpRequest = SignupRequest(nickName: nickName, interests: interests)
-                let _ = try await userClient.회원등록(signUpRequest)
-                
-                await send(.inner(.pushSignUpDoneView))
-            }
-        
-        case .로그인(let response):
-            switch response.provider {
-            case .apple:
-                return .run { send in await send(.inner(.애플로그인(response))) }
-            case .google:
-                return .run { send in await send(.inner(.구글로그인(response))) }
-            }
-        }
-    }
-    /// - Scope Effect
-    func handleScopeAction(_ action: Action.ScopeAction, state: inout State) -> Effect<Action> {
-        switch action {
-        case .agreeToTerms(let delegate):
-            switch delegate {
-            case .pushRegisterNicknameView:
-                return .send(.inner(.pushRegisterNicknameView))
-            }
-        case .registerNickname(let delegate):
-            switch delegate {
-            case .pushSelectFieldView(let nickname):
-                state.nickName = nickname
-                return .send(.inner(.pushSelectFieldView(nickname: nickname)))
-            }
-        case .selectField(let delegate):
-            switch delegate {
-            case let .pushSignUpDoneView(interests):
-                state.interests = interests
-                return .send(.async(.회원가입))
-            }
-        case .signUpDone(let delegate):
-            switch delegate {
-            case .dismissLoginRootView:
-                return .send(.delegate(.dismissLoginRootView))
-            }
-        }
-    }
-    /// - Delegate Effect
-    func handleDelegateAction(_ action: Action.DelegateAction, state: inout State) -> Effect<Action> {
-        return .none
-    }
-
-    func handlePathAction(_ action: StackActionOf<Path>, state: inout State) -> Effect<Action> {
-        switch action {
-        case .element(id: _, action: .agreeToTerms(.delegate(let delegate))):
-            return .send(.scope(.agreeToTerms(delegate)))
-        case .element(id: _, action: .registerNickname(.delegate(let delegate))):
-            return .send(.scope(.registerNickname(delegate)))
-        case .element(id: _, action: .selecteField(.delegate(let delegate))):
-            return .send(.scope(.selectField(delegate)))
-        case .element(id: _, action: .signUpDone(.delegate(let delegate))):
-            return .send(.scope(.signUpDone(delegate)))
-        case .element, .popFrom, .push:
-            return .none
-        }
-    }
-}
-
-//MARK: - Path
-extension LoginRootFeature {
-    @Reducer
-    public enum Path {
-        case agreeToTerms(AgreeToTermsFeature)
-        case registerNickname(RegisterNicknameFeature)
-        case selecteField(SelectFieldFeature)
-        case signUpDone(SignUpDoneFeature)
     }
 }

--- a/Projects/Feature/FeatureLogin/Sources/LoginRoot/LoginRootView.swift
+++ b/Projects/Feature/FeatureLogin/Sources/LoginRoot/LoginRootView.swift
@@ -1,19 +1,17 @@
 //
-//  SignUpNavigationStackView.swift
+//  LoginRootView.swift
 //  Feature
 //
-//  Created by 김도형 on 7/7/24.
+//  Created by 김도형 on 9/7/24.
 
-import ComposableArchitecture
 import SwiftUI
 
-import DSKit
+import ComposableArchitecture
 
-@ViewAction(for: LoginRootFeature.self)
 public struct LoginRootView: View {
     /// - Properties
-    @Perception.Bindable
-    public var store: StoreOf<LoginRootFeature>
+    public let store: StoreOf<LoginRootFeature>
+    
     /// - Initializer
     public init(store: StoreOf<LoginRootFeature>) {
         self.store = store
@@ -23,35 +21,14 @@ public struct LoginRootView: View {
 public extension LoginRootView {
     var body: some View {
         WithPerceptionTracking {
-            NavigationStack(path: $store.scope(state: \.path, action: \.path)) {
-                WithPerceptionTracking {
-                    VStack(spacing: 8) {
-                        logo
-                        
-                        Spacer()
-                        
-                        appleLoginButton
-                            .pokitMaxWidth()
-                        
-                        googleLoginButton
-                            .pokitMaxWidth()
+            Group {
+                switch store.state {
+                case .login:
+                    if let store = store.scope(state: \.login, action: \.login) {
+                        LoginView(store: store)
                     }
-                    .padding(.horizontal, 20)
-                    .padding(.bottom, 36)
-                    .background(.pokit(.bg(.base)))
-                    .ignoresSafeArea(edges: .bottom)
-                    .navigationBarBackButtonHidden()
-                }
-            } destination: { path in
-                WithPerceptionTracking {
-                    switch path.case {
-                    case .agreeToTerms(let store):
-                        AgreeToTermsView(store: store)
-                    case .registerNickname(let store):
-                        RegisterNicknameView(store: store)
-                    case .selecteField(let store):
-                        SelectFieldView(store: store)
-                    case .signUpDone(let store):
+                case .signUpDone:
+                    if let store = store.scope(state: \.signUpDone, action: \.signUpDone) {
                         SignUpDoneView(store: store)
                     }
                 }
@@ -60,114 +37,17 @@ public extension LoginRootView {
     }
 }
 //MARK: - Configure View
-extension LoginRootView {
-    private var logo: some View {
-        HStack {
-            Spacer()
-            
-            VStack(spacing: 24) {
-                Image(.logo(.pokit))
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(height: 72)
-                    .foregroundStyle(.pokit(.icon(.brand)))
-                
-                Text("다양한 링크들을 한 곳에")
-                    .pokitFont(.b1(.b))
-                    .foregroundStyle(.pokit(.text(.secondary)))
-            }
-            
-            Spacer()
-        }
-        .padding(.top, 254)
-    }
+private extension LoginRootView {
     
-    private var appleLoginButton: some View {
-        Button {
-            send(.appleLoginButtonTapped)
-        } label: {
-            appleLoginButtonLabel
-        }
-    }
-    
-    private var appleLoginButtonLabel: some View {
-        VStack {
-            Spacer()
-            
-            HStack(spacing: 12) {
-                Spacer()
-                
-                Image(systemName: "apple.logo")
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(width: 24, height: 24)
-                    .foregroundColor(.pokit(.icon(.inverseWh)))
-                
-                Text("Apple로 계속하기")
-                    .pokitFont(.l1(.r))
-                    .foregroundStyle(.pokit(.text(.inverseWh)))
-                
-                Spacer()
-            }
-            
-            Spacer()
-        }
-        .background {
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(.black)
-                .overlay {
-                    RoundedRectangle(cornerRadius: 8, style: .continuous)
-                        .stroke(.pokit(.border(.secondary)), lineWidth: 1)
-                }
-        }
-        .frame(height: 50)
-    }
-    
-    private var googleLoginButton: some View {
-        Button {
-            send(.googleLoginButtonTapped)
-        } label: {
-            googleLoginButtonLabel
-        }
-    }
-    
-    private var googleLoginButtonLabel: some View {
-        VStack {
-            Spacer()
-            
-            HStack(spacing: 12) {
-                Spacer()
-                
-                Image(.icon(.google))
-                    .resizable()
-                    .frame(width: 24, height: 24)
-                
-                Text("Google로 계속하기")
-                    .pokitFont(.l1(.r))
-                    .foregroundStyle(.pokit(.text(.primary)))
-                
-                Spacer()
-            }
-            
-            Spacer()
-        }
-        .background {
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(.pokit(.bg(.base)))
-                .overlay {
-                    RoundedRectangle(cornerRadius: 8, style: .continuous)
-                        .stroke(.pokit(.border(.secondary)), lineWidth: 1)
-                }
-        }
-        .frame(height: 50)
-    }
 }
 //MARK: - Preview
 #Preview {
     LoginRootView(
         store: Store(
-            initialState: .init(),
+            initialState: .login(.init()),
             reducer: { LoginRootFeature() }
         )
     )
 }
+
+

--- a/Projects/Feature/FeatureLogin/Sources/SelectField/SelectFieldFeature.swift
+++ b/Projects/Feature/FeatureLogin/Sources/SelectField/SelectFieldFeature.swift
@@ -108,7 +108,7 @@ private extension SelectFieldFeature {
     func handleInnerAction(_ action: Action.InnerAction, state: inout State) -> Effect<Action> {
         switch action {
         case let .관심사_목록_조회_결과(interests):
-            interests.forEach { state.fields.append($0.description) }
+            state.fields = interests.map { $0.description }
             return .none
         }
     }

--- a/Projects/Feature/FeatureLogin/Sources/SignUpDone/SignUpDoneFeature.swift
+++ b/Projects/Feature/FeatureLogin/Sources/SignUpDone/SignUpDoneFeature.swift
@@ -36,7 +36,6 @@ public struct SignUpDoneFeature {
         public enum View: Equatable {
             /// - Button Tapped
             case startButtonTapped
-            case backButtonTapped
             
             case firecrackerOnAppeared
             case titleOnAppeared
@@ -84,8 +83,6 @@ private extension SignUpDoneFeature {
         switch action {
         case .startButtonTapped:
             return .send(.delegate(.dismissLoginRootView), animation: .pokitDissolve)
-        case .backButtonTapped:
-            return .run { _ in await self.dismiss() }
         case .firecrackerOnAppeared:
             state.firecrackIsAppear = true
             return .none

--- a/Projects/Feature/FeatureLogin/Sources/SignUpDone/SignUpDoneView.swift
+++ b/Projects/Feature/FeatureLogin/Sources/SignUpDone/SignUpDoneView.swift
@@ -25,10 +25,10 @@ public extension SignUpDoneView {
             VStack(spacing: 0) {
                 Spacer()
                 
-                    logo
-                    
-                    title
-                        .padding(.top, 4)
+                logo
+                
+                title
+                    .padding(.top, 4)
                 
                 Spacer()
                 
@@ -36,6 +36,7 @@ public extension SignUpDoneView {
                     .padding(.top, 78)
             }
             .padding(.horizontal, 20)
+            .background(.pokit(.bg(.base)))
             .overlay(alignment: .bottom) {
                 PokitBottomButton(
                     "시작하기",
@@ -46,16 +47,8 @@ public extension SignUpDoneView {
                 .padding(.horizontal, 20)
                 .background(.pokit(.bg(.base)))
             }
-            .pokitNavigationBar {
-                PokitHeader {
-                    PokitHeaderItems(placement: .leading) {
-                        PokitToolbarButton(.icon(.arrowLeft)) {
-                            send(.backButtonTapped)
-                        }
-                    }
-                }
-            }
             .ignoresSafeArea(edges: .bottom)
+            .navigationBarBackButtonHidden()
         }
     }
 }
@@ -127,5 +120,3 @@ extension SignUpDoneView {
         )
     )
 }
-
-

--- a/Projects/Feature/FeatureLoginDemo/Sources/FeatureLoginDemoApp.swift
+++ b/Projects/Feature/FeatureLoginDemo/Sources/FeatureLoginDemoApp.swift
@@ -14,10 +14,10 @@ struct FeatureLoginDemoApp: App {
     var body: some Scene {
         WindowGroup {
             // TODO: 루트 뷰 추가
-            LoginRootView(
+            LoginView(
                 store: .init(
                     initialState: .init(),
-                    reducer: { LoginRootFeature() }
+                    reducer: { LoginFeature() }
                 )
             )
         }
@@ -25,10 +25,10 @@ struct FeatureLoginDemoApp: App {
 }
 
 #Preview {
-    LoginRootView(
+    LoginView(
         store: .init(
             initialState: .init(),
-            reducer: { LoginRootFeature() }
+            reducer: { LoginFeature() }
         )
     )
 }

--- a/Projects/Feature/FeaturePokit/Sources/PokitRootFeature.swift
+++ b/Projects/Feature/FeaturePokit/Sources/PokitRootFeature.swift
@@ -92,7 +92,7 @@ public struct PokitRootFeature {
             case categoryTapped(BaseCategoryItem)
             case contentItemTapped(BaseContentItem)
 
-            case 링크_공유_완료(completed: Bool)
+            case 링크_공유_완료
 
             case pokitRootViewOnAppeared
 
@@ -244,7 +244,7 @@ private extension PokitRootFeature {
                 return .send(.async(.미분류_카테고리_컨텐츠_페이징_조회))
             default: return .none
             }
-        case .링크_공유_완료(completed: let completed):
+        case .링크_공유_완료:
             state.shareSheetItem = nil
             return .none
         }

--- a/Projects/Feature/FeaturePokit/Sources/PokitRootFeature.swift
+++ b/Projects/Feature/FeaturePokit/Sources/PokitRootFeature.swift
@@ -245,7 +245,6 @@ private extension PokitRootFeature {
             default: return .none
             }
         case .링크_공유_완료(completed: let completed):
-            guard completed else { return .none }
             state.shareSheetItem = nil
             return .none
         }

--- a/Projects/Feature/FeaturePokit/Sources/PokitRootView.swift
+++ b/Projects/Feature/FeaturePokit/Sources/PokitRootView.swift
@@ -49,7 +49,7 @@ public extension PokitRootView {
                 if let shareURL = URL(string: content.data) {
                     PokitShareSheet(
                         items: [shareURL],
-                        completion: { send(.링크_공유_완료(completed: $0)) }
+                        completion: { send(.링크_공유_완료) }
                     )
                     .presentationDetents([.medium, .large])
                 }

--- a/Projects/Feature/FeatureRemind/Sources/Remind/RemindFeature.swift
+++ b/Projects/Feature/FeatureRemind/Sources/Remind/RemindFeature.swift
@@ -78,7 +78,7 @@ public struct RemindFeature {
             )
             case deleteAlertConfirmTapped(content: BaseContentItem)
             
-            case 링크_공유_완료(completed: Bool)
+            case 링크_공유_완료
             
             case remindViewOnAppeared
         }
@@ -175,7 +175,7 @@ private extension RemindFeature {
                 await send(.async(.읽지않음_컨텐츠_조회), animation: .pokitDissolve)
                 await send(.async(.즐겨찾기_링크모음_조회), animation: .pokitDissolve)
             }
-        case .링크_공유_완료(completed: let completed):
+        case .링크_공유_완료:
             state.shareSheetItem = nil
             return .none
         }

--- a/Projects/Feature/FeatureRemind/Sources/Remind/RemindFeature.swift
+++ b/Projects/Feature/FeatureRemind/Sources/Remind/RemindFeature.swift
@@ -176,7 +176,6 @@ private extension RemindFeature {
                 await send(.async(.즐겨찾기_링크모음_조회), animation: .pokitDissolve)
             }
         case .링크_공유_완료(completed: let completed):
-            guard completed else { return .none }
             state.shareSheetItem = nil
             return .none
         }

--- a/Projects/Feature/FeatureRemind/Sources/Remind/RemindView.swift
+++ b/Projects/Feature/FeatureRemind/Sources/Remind/RemindView.swift
@@ -42,7 +42,7 @@ public extension RemindView {
                     if let shareURL = URL(string: content.data) {
                         PokitShareSheet(
                             items: [shareURL],
-                            completion: { send(.링크_공유_완료(completed: $0)) }
+                            completion: { send(.링크_공유_완료) }
                         )
                         .presentationDetents([.medium, .large])
                     }

--- a/Projects/Feature/FeatureSetting/Sources/Search/PokitSearchFeature.swift
+++ b/Projects/Feature/FeatureSetting/Sources/Search/PokitSearchFeature.swift
@@ -332,7 +332,6 @@ private extension PokitSearchFeature {
             state.domain.condition.isRead = false
             return .send(.inner(.페이징_초기화))
         case .링크_공유_완료(completed: let completed):
-            guard completed else { return .none }
             state.shareSheetItem = nil
             return .none
         case .로딩_isPresented:

--- a/Projects/Feature/FeatureSetting/Sources/Search/PokitSearchFeature.swift
+++ b/Projects/Feature/FeatureSetting/Sources/Search/PokitSearchFeature.swift
@@ -126,7 +126,7 @@ public struct PokitSearchFeature {
             /// - TextInput OnSubmitted
             case searchTextInputOnSubmitted
             
-            case 링크_공유_완료(completed: Bool)
+            case 링크_공유_완료
             
             case onAppear
             case 로딩_isPresented
@@ -331,7 +331,7 @@ private extension PokitSearchFeature {
         case .unreadChipTapped:
             state.domain.condition.isRead = false
             return .send(.inner(.페이징_초기화))
-        case .링크_공유_완료(completed: let completed):
+        case .링크_공유_완료:
             state.shareSheetItem = nil
             return .none
         case .로딩_isPresented:

--- a/Projects/Feature/FeatureSetting/Sources/Search/PokitSearchView.swift
+++ b/Projects/Feature/FeatureSetting/Sources/Search/PokitSearchView.swift
@@ -60,7 +60,7 @@ public extension PokitSearchView {
                 if let shareURL = URL(string: content.data) {
                     PokitShareSheet(
                         items: [shareURL],
-                        completion: { send(.링크_공유_완료(completed: $0)) }
+                        completion: { send(.링크_공유_완료) }
                     )
                     .presentationDetents([.medium, .large])
                 }

--- a/Projects/Feature/FeatureSetting/Sources/Setting/PokitSettingFeature.swift
+++ b/Projects/Feature/FeatureSetting/Sources/Setting/PokitSettingFeature.swift
@@ -213,30 +213,31 @@ private extension PokitSettingFeature {
                     return
                 }
                 
-                guard let authCode = userDefaults.stringKey(.authCode) else {
-                    print("authCode가 없어서 벗어남")
-                    return
+                if platform == "애플" {
+                    guard let authCode = userDefaults.stringKey(.authCode) else {
+                        print("authCode가 없어서 벗어남")
+                        return
+                    }
+                    
+                    guard let jwt = userDefaults.stringKey(.jwt) else {
+                        print("jwt가 없어서 벗어남")
+                        return
+                    }
+                    
+                    guard let serverRefreshToken = keychain.read(.serverRefresh) else { return }
+                    
+                    try await authClient.appleRevoke(
+                        serverRefreshToken,
+                        AppleTokenRequest(
+                            authCode: authCode,
+                            jwt: jwt
+                        )
+                    )
                 }
-                
-                guard let jwt = userDefaults.stringKey(.jwt) else {
-                    print("jwt가 없어서 벗어남")
-                    return
-                }
-                
-                guard let serverRefreshToken = keychain.read(.serverRefresh) else { return }
                 
                 await send(.async(.키_제거))
                 
-                try await authClient.appleRevoke(
-                    serverRefreshToken,
-                    AppleTokenRequest(
-                        authCode: authCode,
-                        jwt: jwt
-                    )
-                )
-                
                 let request = WithdrawRequest(
-                    refreshToken: serverRefreshToken,
                     authPlatform: platform
                 )
                 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #111 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 컨텐츠 상세에서, 즐겨찾기와 컨텐츠 조회 액션이 발생했을 시, 부모 뷰 에게 전달하는 시점을 변경하였습니다.
- 컨텐츠 공유로 공유 시트를 띄웠을 시에 공유시트의 닫기 버튼을 눌렀을 시에 닫히지 않는 문제를 수정하였습니다.
- 구글 로그인 회원 탈퇴 시 우리 서버로 탈퇴 요청이 실행되지 않는 문제를 수정하였습니다.
- 회원가입 완료 시 뒤로가기 버튼을 없애기 위해 `LoginRootFeature`를 `LoginFeature` <-> `SignUpFeature` 간 `ifCaseLet` 처리로 바꿨습니다.

### 스크린샷 (선택)
![Simulator Screen Recording - iPhone 15 Pro - 2024-09-07 at 19 03 53](https://github.com/user-attachments/assets/056ebeb6-9b12-414d-98c1-3d0c9c96cd23)

![Simulator Screen Recording - iPhone 15 Pro - 2024-09-07 at 19 04 48](https://github.com/user-attachments/assets/961884fe-f210-4d4f-af67-c8c8b0cbb187)

![Simulator Screen Recording - iPhone 15 Pro - 2024-09-07 at 19 07 20](https://github.com/user-attachments/assets/e09e7a92-f0c2-4120-876a-28f07338dbcd)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>

- 앱 멈춤 현상을 해결하기 위해 컨텐츠 상세에서 부모 뷰에 액션 전달 시점을 바꿔보았지만, `ifLet`오류만 사라졌을 뿐 증상은 동일하였습니다. (제 생각에는 TCA의 고질적 문제가 아닐까...)
- 어쩌다 보니 구글로그인 회원탈퇴가 안되는 것을 발견하여 해결하였습니다. (안고치기엔 너무 치명적인거 같았어요)
- 회원 탈퇴 고치면서 회원가입 완료 화면에 뒤로가기를 비활성화 하였습니다.
- 굳이 굳이 힘들게 `ifCaseLet`로 바꾼 이유는 저희가 뒤로가기 버튼을 커스텀 하면서, 뒤로가기 제스처를 강제로 활성화 시켰기 때문입니다. 이로 인해 버튼이 안보여도 뒤로가기가 가능해지는 문제를 보였고, 아예 화면 플로우를 자체를 분리 시켰습니다.
- `ifCaseLet` 처리를 하다가 문득 든 생각은.. Pokit <-> Remind 화면간 전환에 `TabView`를 쓸 필요가 있나? 싶었습니다. 어떻게 생각하시는지 궁금해요.

close 이슈번호
