### PR TITLE
fix: fcm 분기처리 수정

### DIFF
--- a/Projects/App/Resources/Pokit-info.plist
+++ b/Projects/App/Resources/Pokit-info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>1.0.1</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/Projects/App/Sources/AppDelegate/AppDelegateFeature.swift
+++ b/Projects/App/Sources/AppDelegate/AppDelegateFeature.swift
@@ -21,6 +21,7 @@ public struct AppDelegateFeature {
     @ObservableState
     public struct State {
         public var root = RootFeature.State()
+        @Shared(.inMemory("PushTapped")) var isPushTapped: Bool = false
         
         public init() {}
     }
@@ -80,6 +81,7 @@ public struct AppDelegateFeature {
                 return .run { _ in completionHandler(.banner) }
                 
             case let .userNotifications(.didReceiveResponse(_, completionHandler)):
+                state.isPushTapped = true
                 return .run { @MainActor _ in completionHandler() }
             case .userNotifications:
                 return .none

--- a/Projects/App/Sources/AppDelegate/AppDelegateFeature.swift
+++ b/Projects/App/Sources/AppDelegate/AppDelegateFeature.swift
@@ -59,11 +59,8 @@ public struct AppDelegateFeature {
                         group.addTask {
                             let setting = await self.userNotifications.getNotificationSettings()
                             switch setting.authorizationStatus {
-                            case .authorized:
+                            case .authorized, .notDetermined:
                                 guard try await self.userNotifications.requestAuthorization([.alert, .sound])
-                                else { return }
-                            case .notDetermined, .provisional:
-                                guard try await self.userNotifications.requestAuthorization(.provisional)
                                 else { return }
                             default: return
                             }

--- a/Projects/App/Sources/Intro/IntroFeature.swift
+++ b/Projects/App/Sources/Intro/IntroFeature.swift
@@ -68,9 +68,6 @@ private extension IntroFeature {
             
         case .delegate(.loginNeeded):
             return .run { send in
-                /// 알람을 통해 앱을 들어왔으나 자동 로그인을 실패했다면 배너로 이동하지 못하게 flag 삭제
-                await userDefaults.removeBool(.fromBanner)
-                /// Todo: 원하는 애니메이션 넣어줘~
                 await send(._sceneChange(.login()), animation: .smooth)
             }
             

--- a/Projects/App/Sources/MainTab/MainTabPath.swift
+++ b/Projects/App/Sources/MainTab/MainTabPath.swift
@@ -62,6 +62,7 @@ public extension MainTabFeature {
             case .pokit(.delegate(.alertButtonTapped)),
                  .remind(.delegate(.alertButtonTapped)),
                  .delegate(.알림함이동):
+                state.isPushTapped = false
                 state.path.append(.알림함(PokitAlertBoxFeature.State()))
                 return .none
 

--- a/Projects/CoreKit/Sources/Data/Client/UserDefaults/UserDefaultsKey.swift
+++ b/Projects/CoreKit/Sources/Data/Client/UserDefaults/UserDefaultsKey.swift
@@ -10,8 +10,6 @@ import Foundation
 public enum UserDefaultsKey {
     public enum BoolKey: String {
         case autoSaveSearch
-        /// - 배너를 클릭해서 들어왔을 때
-        case fromBanner
     }
     public enum StringKey: String {
         /// `구글` or `애플`


### PR DESCRIPTION
## #️⃣연관된 이슈

#111

## 📝작업 내용

푸시알람을 통해 앱을 진입하는 경우의 분기처리를 추가했습니다.
- 앱을 사용중일 때 푸시알람이 오는경우
- 앱을 미사용중일 때 푸시알람이 오는경우

분기처리는 MainTabFeature에서 담당하게 됩니다.
```swift
@Shared(.inMemory("PushTapped")) var isPushTapped: Bool = false
```
TCA의 Shared를 통해 이를 쉽게 관리 할 수 있습니다. 해당 프로퍼티는 총 2가지의 파일에서 추적합니다. 
:: `AppDelegateFeature`, `MainTabFeature`


```swift
case let .userNotifications(.didReceiveResponse(_, completionHandler)):
    state.isPushTapped = true
    return .run { @MainActor _ in completionHandler() }
```
푸시를 누르면 isPushTapped의 값을 true로 바꿉니다. 
Shared의 option을 inMemory로 설정했기 때문에 앱이 실행되는 순간에만 값이 남아있습니다.
당연하게도 `PushTapped`라는 키값을 두 가지 파일에서 같이 사용하고 있기 때문에 flag가 바뀐 것을 MainTabFeature도 알아차릴 수 있습니다.

```swift
case .onAppear:
    if state.isPushTapped {
        return .send(.pushAlertTapped(true))
    }
    return .merge(
        .run { send in
            // ...
        },
        .publisher {
            state.$isPushTapped.publisher
                .map(Action.pushAlertTapped)
        }
    )
```
publisher를 통해 바뀐 값을 감지할 수 있습니다. 하지만 이는 앱 실행중에 알아차릴 수 있는 것 뿐이고, 푸시를 통해 앱을 실행하는 경우에는 알아차릴 수 없습니다. 따라서 상단 if문을 추가해 AppDelegateFeature로부터 바뀐 값을 통해 알림함으로 이동되게 만들었습니다.
```swift
case .delegate(.알림함이동):
    state.isPushTapped = false
    state.path.append(.알림함(PokitAlertBoxFeature.State()))
return .none
```
이후 알림함으로 이동 될 때 flag를 꺼주시면 됩니다.
### 스크린샷 (선택)
| <img src="https://github.com/user-attachments/assets/61ae0cf4-c0fd-489a-afcf-df6da185f53d" alt="앱 사용중일 때" width="150"> | <img src="https://github.com/user-attachments/assets/f778fec7-6142-4992-8af2-459634615b45" alt="앱 실행할 때" width="150"> |
|:-:|:-:|
|`앱 사용중일 때` | `앱 실행할 때` |
## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?