### PR TITLE
fix: 카테고리 추가 후 링크 추가 및 수정화면 반영

### DIFF
--- a/Projects/App/Sources/MainTab/MainTabFeature.swift
+++ b/Projects/App/Sources/MainTab/MainTabFeature.swift
@@ -38,6 +38,7 @@ public struct MainTabFeature {
         var pokit: PokitRootFeature.State
         var remind: RemindFeature.State = .init()
         @Presents var contentDetail: ContentDetailFeature.State?
+        @Shared(.inMemory("SelectCategory")) var selectedPokit: BaseCategoryItem?
         
         public init() {
             self.pokit = .init()
@@ -144,7 +145,7 @@ private extension MainTabFeature {
             state.isBottomSheetPresented = false
             switch type {
             case .링크추가: return .send(.delegate(.링크추가하기))
-            case .포킷추가: return .send(.delegate(.포킷추가하기))   
+            case .포킷추가: return .send(.delegate(.포킷추가하기))
             }
             
         case .linkCopyButtonTapped:

--- a/Projects/App/Sources/MainTab/MainTabPath.swift
+++ b/Projects/App/Sources/MainTab/MainTabPath.swift
@@ -156,13 +156,13 @@ public extension MainTabFeature {
                 }
 
             case let .inner(.링크추가및수정이동(contentId: id)):
-                state.path.append(.링크추가및수정(
-                    ContentSettingFeature.State(contentId: id)
-                ))
+                state.selectedPokit = nil
+                state.path.append(.링크추가및수정(ContentSettingFeature.State(contentId: id)))
                 return .send(.contentDetail(.dismiss))
 
             /// - 링크 추가하기
             case .delegate(.링크추가하기):
+                state.selectedPokit = nil
                 state.path.append(.링크추가및수정(ContentSettingFeature.State(urlText: state.link)))
                 state.link = nil
                 return .none
@@ -238,4 +238,3 @@ public extension MainTabFeature {
         .forEach(\.path, action: \.path) { MainTabPath() }
     }
 }
-


### PR DESCRIPTION
## #️⃣연관된 이슈

#111

## 📝작업 내용

링크 추가 화면에서 카테고리를 추가한 후 이전 화면으로 돌아오면 등록한 카테고리가 적용될 수 있게 수정했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

