### PR TITLE
fix: 카테고리 설정 버그 수정

### DIFF
--- a/Projects/App/Resources/Pokit-info.plist
+++ b/Projects/App/Resources/Pokit-info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.2</string>
+	<string>1.0.3</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/Projects/App/Sources/MainTab/MainTabFeature.swift
+++ b/Projects/App/Sources/MainTab/MainTabFeature.swift
@@ -38,7 +38,7 @@ public struct MainTabFeature {
         var pokit: PokitRootFeature.State
         var remind: RemindFeature.State = .init()
         @Presents var contentDetail: ContentDetailFeature.State?
-        @Shared(.inMemory("SelectCategory")) var selectedPokit: BaseCategoryItem?
+        @Shared(.inMemory("SelectCategory")) var categoryId: Int?
         @Shared(.inMemory("PushTapped")) var isPushTapped: Bool = false
 
         public init() {

--- a/Projects/App/Sources/MainTab/MainTabPath.swift
+++ b/Projects/App/Sources/MainTab/MainTabPath.swift
@@ -160,9 +160,9 @@ public extension MainTabFeature {
 
             case let .inner(.링크추가및수정이동(contentId: id)):
                 state.categoryId = nil
+                state.contentDetail = nil
                 state.path.append(.링크추가및수정(ContentSettingFeature.State(contentId: id)))
-                return .send(.contentDetail(.dismiss))
-
+                return .none
             /// - 링크 추가하기
             case .delegate(.링크추가하기):
                 state.categoryId = nil

--- a/Projects/App/Sources/MainTab/MainTabPath.swift
+++ b/Projects/App/Sources/MainTab/MainTabPath.swift
@@ -159,13 +159,13 @@ public extension MainTabFeature {
                 }
 
             case let .inner(.링크추가및수정이동(contentId: id)):
-                state.selectedPokit = nil
+                state.categoryId = nil
                 state.path.append(.링크추가및수정(ContentSettingFeature.State(contentId: id)))
                 return .send(.contentDetail(.dismiss))
 
             /// - 링크 추가하기
             case .delegate(.링크추가하기):
-                state.selectedPokit = nil
+                state.categoryId = nil
                 state.path.append(.링크추가및수정(ContentSettingFeature.State(urlText: state.link)))
                 state.link = nil
                 return .none

--- a/Projects/Feature/FeatureCategorySetting/Sources/PokitCategorySettingFeature.swift
+++ b/Projects/Feature/FeatureCategorySetting/Sources/PokitCategorySettingFeature.swift
@@ -51,7 +51,7 @@ public struct PokitCategorySettingFeature {
         let type: SettingType
         var isProfileSheetPresented: Bool = false
         var pokitNameTextInpuState: PokitInputStyle.State = .default
-        @Shared(.inMemory("SelectCategory")) var selectCateogry: BaseCategoryItem?
+        @Shared(.inMemory("SelectCategory")) var categoryId: Int?
         /// - 포킷 수정 API / 추가 API
         /// categoryName
         /// categoryImageId
@@ -242,7 +242,7 @@ private extension PokitCategorySettingFeature {
             return .none
             
         case let .카테고리_인메모리_저장(response):
-            state.selectCateogry = response
+            state.categoryId = response.id
             return .none
         }
     }

--- a/Projects/Feature/FeatureCategorySetting/Sources/PokitCategorySettingView.swift
+++ b/Projects/Feature/FeatureCategorySetting/Sources/PokitCategorySettingView.swift
@@ -73,16 +73,18 @@ private extension PokitCategorySettingView {
                     .resizable()
                     .roundedCorner(12, corners: .allCorners)
             } else {
-                ZStack {
-                    Color.pokit(.bg(.disable))
-                    
-                    if store.selectedProfile?.imageURL != nil {
-                        PokitSpinner()
-                            .foregroundStyle(.pokit(.icon(.brand)))
-                            .frame(width: 48, height: 48)
+                WithPerceptionTracking {
+                    ZStack {
+                        Color.pokit(.bg(.disable))
+                        
+                        if store.selectedProfile?.imageURL != nil {
+                            PokitSpinner()
+                                .foregroundStyle(.pokit(.icon(.brand)))
+                                .frame(width: 48, height: 48)
+                        }
                     }
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
                 }
-                .clipShape(RoundedRectangle(cornerRadius: 12))
             }
         }
         .frame(width: 80, height: 80)

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         // Add your own dependencies here:
         // .package(url: "https://github.com/Alamofire/Alamofire", from: "5.0.0"),
         // You can read more about dependencies here: https://docs.tuist.io/documentation/tuist/dependencies
-        .package(url: "https://github.com/pointfreeco/swift-composable-architecture", from: "1.10.4"),
+        .package(url: "https://github.com/pointfreeco/swift-composable-architecture", "1.10.4" ..< "1.11.1"),
         .package(url: "https://github.com/google/GoogleSignIn-iOS", "7.0.0" ..< "7.1.0"),
         .package(url: "https://github.com/Moya/Moya", from: "15.0.0"),
         .package(url: "https://github.com/firebase/firebase-ios-sdk", "10.28.0" ..< "10.28.1"),


### PR DESCRIPTION
## #️⃣연관된 이슈

#120

## 📝작업 내용
- 1.0.3 버전 수정 및 tca 버전 고정

- Perception Tracking 경고 수정

CategorySetting에서 발생하는 Perception Tracking은 총 2가지 케이스입니다.
1. Lazy한 View에 WithPerceptionTracking을 붙이지 않았을 때
2. ifLet

1번의 경우 클로저 뷰에 Perception을 감싸는 것으로 해결되었습니다.
2번의 경우 링크 추가 / 수정화면으로 이동된 후 contentDetail을 dismiss하고 있어서, 즉 순서가 바뀌었기 때문에 발생

`as is`: 링크추가수정화면 나타남 -> 화면에 컨텐츠상세 시트가 없는데 dismiss action 발생함 -> ??
`to be`: 시트 내림(nil) -> 링크 추가 수정화면 나타남
<br>
- 링크 수정에서 카테고리를 추가하고 돌아오면 적용이 안되는 버그 수정

작업하면서 알게 된 사실인데 링크 추가 / 수정 로직을 분리해놓을 필요가 있을 것 같습니다. (거의 엉켜있다시피함)



### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
